### PR TITLE
Migrate to the `lathe-comforts/own-contract` DSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
             racket-catalogs-id: "racksnaps"
             racket-catalogs: |
               https://download.racket-lang.org/releases/8.3/catalog/,
-              https://racksnaps.defn.io/built-snapshots/2022/01/23/catalog/
+              https://racksnaps.defn.io/built-snapshots/2022/02/08/catalog/
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/punctaffy-doc/scribblings/private/shim.rkt
+++ b/punctaffy-doc/scribblings/private/shim.rkt
@@ -5,7 +5,7 @@
 ; Import lists, debugging constants, and other utilities that are
 ; useful primarily for this codebase.
 
-;   Copyright 2021 The Lathe Authors
+;   Copyright 2021, 2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@
         (only-in #,(break 'racket/contract) struct-type-property/c)
         (only-in #,(break 'racket/contract/base)
           -> </c and/c any/c contract? flat-contract? ->i list/c
-          listof or/c)
+          listof not/c or/c)
         (only-in #,(break 'racket/extflonum) extflonum?)
         (only-in #,(break 'racket/flonum) flvector?)
         (only-in #,(break 'racket/fixnum) fxvector?)

--- a/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
+++ b/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
@@ -2189,7 +2189,7 @@ A hypernest is a generalization of an s-expression or other syntax tree. In an s
       (let ([_dim/c (dim-sys-dim/c ds)])
         (or/c
           (hypertee-bracket/c _dim/c)
-          (and/c (not/c hypertee-bracket?) _dim/c))]
+          (and/c (not/c hypertee-bracket?) _dim/c)))]
     ...)
   (hypertee/c ds)
 ]{

--- a/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
+++ b/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
@@ -2569,7 +2569,9 @@ A hypernest is a generalization of an s-expression or other syntax tree. In an s
     [degree (dim-sys-dim/c ds)]
     [bracket
       (let ([_dim/c (dim-sys-dim/c ds)])
-        (or/c (hypernest-bracket/c _dim/c) _dim/c))]
+        (or/c
+          (hypernest-bracket/c _dim/c)
+          (and/c (not/c hypernest-bracket?) _dim/c)))]
     ...)
   (hypernest/c (hypertee-snippet-format-sys) ds)
 ]{

--- a/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
+++ b/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
@@ -4,7 +4,7 @@
 @;
 @; Hypersnippet data structures and interfaces.
 
-@;   Copyright 2020, 2021 The Lathe Authors
+@;   Copyright 2020-2022 The Lathe Authors
 @;
 @;   Licensed under the Apache License, Version 2.0 (the "License");
 @;   you may not use this file except in compliance with the License.
@@ -2187,7 +2187,9 @@ A hypernest is a generalization of an s-expression or other syntax tree. In an s
     [degree (dim-sys-dim/c ds)]
     [bracket
       (let ([_dim/c (dim-sys-dim/c ds)])
-        (or/c (hypertee-bracket/c _dim/c) _dim/c))]
+        (or/c
+          (hypertee-bracket/c _dim/c)
+          (and/c (not/c hypertee-bracket?) _dim/c))]
     ...)
   (hypertee/c ds)
 ]{

--- a/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
+++ b/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
@@ -2142,13 +2142,13 @@ A hypernest is a generalization of an s-expression or other syntax tree. In an s
   @defidform[hypertee-furl]
   @defform[
     #:link-target? #f
-    (hypertee-furl dim-sys coil)
-    #:contracts ([dim-sys dim-sys?] [coil (hypertee-coil/c dim-sys)])
+    (hypertee-furl ds coil)
+    #:contracts ([ds dim-sys?] [coil (hypertee-coil/c ds)])
   ]
   @defform[
     #:kind "match expander"
     #:link-target? #f
-    (hypertee-furl dim-sys coil)
+    (hypertee-furl ds coil)
   ]
 )]{
   Constructs or deconstructs a @tech{hypertee} value, regarding it as being made up of a @tech{dimension system} and a @racket[hypertee-coil/c] value.

--- a/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
+++ b/punctaffy-doc/scribblings/punctaffy/hypersnippet.scrbl
@@ -2522,13 +2522,13 @@ A hypernest is a generalization of an s-expression or other syntax tree. In an s
   @defidform[hypernest-furl]
   @defform[
     #:link-target? #f
-    (hypernest-furl dim-sys coil)
-    #:contracts ([dim-sys dim-sys?] [coil (hypernest-coil/c dim-sys)])
+    (hypernest-furl ds coil)
+    #:contracts ([ds dim-sys?] [coil (hypernest-coil/c ds)])
   ]
   @defform[
     #:kind "match expander"
     #:link-target? #f
-    (hypernest-furl dim-sys coil)
+    (hypernest-furl ds coil)
   ]
 )]{
   Constructs or deconstructs a @tech{hypernest} value, regarding it as being made up of a @tech{dimension system} and a @racket[hypernest-coil/c] value.

--- a/punctaffy-lib/hypersnippet/dim.rkt
+++ b/punctaffy-lib/hypersnippet/dim.rkt
@@ -5,7 +5,7 @@
 ; Interfaces to represent numbers that represent the dimensionality of
 ; hypersnippets.
 
-;   Copyright 2019, 2020, 2022 The Lathe Authors
+;   Copyright 2019-2020, 2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -62,10 +62,6 @@
   make-atomic-set-element-sys-impl-from-contract ok/c
   prop:atomic-set-element-sys)
 
-; TODO NOW: Remove uses of `lathe-morphisms/private/shim`,
-; particularly including `shim-contract-out` and
-; `shim-recontract-out`.
-(require lathe-morphisms/private/shim)
 (require punctaffy/private/shim)
 (init-shim)
 
@@ -103,241 +99,137 @@
 
 (provide
   dim-sys-category-sys)
-(provide #/shim-contract-out
-  [dim-sys-category-sys? (-> any/c boolean?)]
-  [functor-from-dim-sys-sys-apply-to-morphism
-    (->i
-      (
-        [fs (functor-sys/c dim-sys-category-sys? any/c)]
-        [dsms dim-sys-morphism-sys?])
-      [_ (fs dsms)
-        (category-sys-morphism/c (functor-sys-target fs)
-          (functor-sys-apply-to-object fs
-            (dim-sys-morphism-sys-source dsms))
-          (functor-sys-apply-to-object fs
-            (dim-sys-morphism-sys-target dsms)))])]
-  [natural-transformation-from-from-dim-sys-sys-apply-to-morphism
-    (->i
-      (
-        [nts
-          (natural-transformation-sys/c
-            dim-sys-category-sys? any/c any/c any/c)]
-        [dsms dim-sys-morphism-sys?])
-      [_ (nts dsms)
-        (category-sys-morphism/c
-          (natural-transformation-sys-endpoint-target nts)
-          (functor-sys-apply-to-object
-            (natural-transformation-sys-source nts)
-            (dim-sys-morphism-sys-source dsms))
-          (functor-sys-apply-to-object
-            (natural-transformation-sys-target nts)
-            (dim-sys-morphism-sys-target dsms)))])]
-  [dim-sys-endofunctor-sys? (-> any/c boolean?)]
-  [make-dim-sys-endofunctor-sys-impl-from-apply
-    (->
-      (-> dim-sys-endofunctor-sys? dim-sys? dim-sys?)
-      (->i
-        (
-          [es dim-sys-endofunctor-sys?]
-          [ms dim-sys-morphism-sys?])
-        [_ (es ms)
-          (dim-sys-morphism-sys/c
-            (ok/c
-              (functor-sys-apply-to-object es
-                (dim-sys-morphism-sys-source ms)))
-            (ok/c
-              (functor-sys-apply-to-object es
-                (dim-sys-morphism-sys-target ms))))])
-      functor-sys-impl?)])
+(provide #/own-contract-out
+  dim-sys-category-sys?
+  functor-from-dim-sys-sys-apply-to-morphism
+  natural-transformation-from-from-dim-sys-sys-apply-to-morphism
+  dim-sys-endofunctor-sys?
+  make-dim-sys-endofunctor-sys-impl-from-apply)
 
 ; TODO: Document these exports if we ever need them. We would comment
 ; them out, but they're currently in use by some internal experiments.
 ;#;
-(provide #/shim-contract-out
-  [dim-successors-sys? (-> any/c boolean?)]
-  [dim-successors-sys-impl? (-> any/c boolean?)]
-  [dim-successors-sys-dim-sys (-> dim-successors-sys? dim-sys?)]
-  [dim-successors-sys-dim-plus-int
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [d (dss) (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
-        [n exact-integer?])
-      [_ (dss)
-        (maybe/c #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])]
-  [dim-successors-sys-dim-from-int
-    (->i ([dss dim-successors-sys?] [n exact-integer?])
-      [_ (dss)
-        (maybe/c #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])]
-  [dim-successors-sys-dim=plus-int?
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [candidate (dss)
-          (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
-        [d (dss) (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
-        [n exact-integer?])
-      [_ boolean?])]
-  [prop:dim-successors-sys
-    (struct-type-property/c dim-successors-sys-impl?)]
-  [make-dim-successors-sys-impl-from-dim-plus-int
-    (->
-      (-> dim-successors-sys? dim-sys?)
-      (->i
-        (
-          [dss dim-successors-sys?]
-          [d (dss)
-            (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
-          [n exact-integer?])
-        [_ (dss n)
-          (maybe/c
-          #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])
-      dim-successors-sys-impl?)]
+(provide #/own-contract-out
+  dim-successors-sys?
+  dim-successors-sys-impl?
+  dim-successors-sys-dim-sys
+  dim-successors-sys-dim-plus-int
+  dim-successors-sys-dim-from-int
+  dim-successors-sys-dim=plus-int?
+  prop:dim-successors-sys
+  make-dim-successors-sys-impl-from-dim-plus-int
   
   )
 
 ; TODO: Uncomment these exports if we ever need them.
 ;(provide successorless-dim-successors-sys)
-;(provide #/shim-contract-out
-;  [successorless-dim-successors-sys? (-> any/c boolean?)])
+;(provide #/own-contract-out
+;  successorless-dim-successors-sys?)
 (provide
   nat-dim-sys)
-(provide #/shim-contract-out
-  [nat-dim-sys? (-> any/c boolean?)])
+(provide #/own-contract-out
+  nat-dim-sys?)
 ; TODO: Document this export if we ever need it. We would comment it
 ; out, but it's currently in use by some internal experiments.
 ;#;
 (provide
   nat-dim-successors-sys)
 ; TODO: Uncomment this export if we ever need it.
-;(provide #/shim-contract-out
-;  [nat-dim-successors-sys? (-> any/c boolean?)])
+;(provide #/own-contract-out
+;  nat-dim-successors-sys?)
 (provide
   extended-with-top-dim-finite)
-(provide #/shim-contract-out
-  [extended-with-top-dim-finite? (-> any/c boolean?)]
-  [extended-with-top-dim-finite-original
-    (-> extended-with-top-dim-finite? any/c)])
+(provide #/own-contract-out
+  extended-with-top-dim-finite?
+  extended-with-top-dim-finite-original)
 (provide
   extended-with-top-dim-infinite)
-(provide #/shim-contract-out
-  [extended-with-top-dim-infinite? (-> any/c boolean?)])
-(provide #/shim-contract-out
-  [extended-with-top-dim? (-> any/c boolean?)]
-  [extended-with-top-dim/c (-> contract? contract?)]
-  [extended-with-top-dim=?
-    (->
-      (-> any/c any/c boolean?)
-      extended-with-top-dim?
-      extended-with-top-dim?
-      boolean?)])
+(provide #/own-contract-out
+  extended-with-top-dim-infinite?)
+(provide #/own-contract-out
+  extended-with-top-dim?
+  extended-with-top-dim/c
+  extended-with-top-dim=?)
 (provide
   extended-with-top-dim-sys)
-(provide #/shim-contract-out
-  [extended-with-top-dim-sys? (-> any/c boolean?)]
-  [extended-with-top-dim-sys-original
-    (-> extended-with-top-dim-sys? dim-sys?)])
+(provide #/own-contract-out
+  extended-with-top-dim-sys?
+  extended-with-top-dim-sys-original)
 (provide
   extended-with-top-dim-sys-morphism-sys)
-(provide #/shim-contract-out
-  [extended-with-top-dim-sys-morphism-sys? (-> any/c boolean?)]
-  [extended-with-top-dim-sys-morphism-sys-original
-    (-> extended-with-top-dim-sys-morphism-sys?
-      dim-sys-morphism-sys?)])
+(provide #/own-contract-out
+  extended-with-top-dim-sys-morphism-sys?
+  extended-with-top-dim-sys-morphism-sys-original)
 (provide
   extended-with-top-dim-sys-endofunctor-sys)
-(provide #/shim-contract-out
-  [extended-with-top-dim-sys-endofunctor-sys? (-> any/c boolean?)])
+(provide #/own-contract-out
+  extended-with-top-dim-sys-endofunctor-sys?)
 (provide
   extend-with-top-dim-sys-morphism-sys)
-(provide #/shim-contract-out
-  [extend-with-top-dim-sys-morphism-sys? (-> any/c boolean?)]
-  [extend-with-top-dim-sys-morphism-sys-source
-    (-> extend-with-top-dim-sys-morphism-sys? dim-sys?)])
+(provide #/own-contract-out
+  extend-with-top-dim-sys-morphism-sys?
+  extend-with-top-dim-sys-morphism-sys-source)
 (provide
   extended-with-top-finite-dim-sys)
-(provide #/shim-contract-out
-  [extended-with-top-finite-dim-sys? (-> any/c boolean?)]
-  [extended-with-top-finite-dim-sys-original
-    (-> extended-with-top-finite-dim-sys? dim-sys?)])
+(provide #/own-contract-out
+  extended-with-top-finite-dim-sys?
+  extended-with-top-finite-dim-sys-original)
 (provide
   unextend-with-top-dim-sys-morphism-sys)
-(provide #/shim-contract-out
-  [unextend-with-top-dim-sys-morphism-sys? (-> any/c boolean?)]
-  [unextend-with-top-dim-sys-morphism-sys-target
-    (-> unextend-with-top-dim-sys-morphism-sys? dim-sys?)])
+(provide #/own-contract-out
+  unextend-with-top-dim-sys-morphism-sys?
+  unextend-with-top-dim-sys-morphism-sys-target)
 (provide
   extended-with-top-dim-successors-sys)
-(provide #/shim-contract-out
-  [extended-with-top-dim-successors-sys? (-> any/c boolean?)]
-  [extended-with-top-dim-successors-sys-original
-    (-> extended-with-top-dim-successors-sys? dim-successors-sys?)])
+(provide #/own-contract-out
+  extended-with-top-dim-successors-sys?
+  extended-with-top-dim-successors-sys-original)
 ; TODO: Uncomment these exports if we ever need them.
 #|
 (provide
   fin-multiplied-dim)
-(provide #/shim-contract-out
-  [fin-multiplied-dim? (-> any/c boolean?)]
-  [fin-multiplied-dim-index (-> fin-multiplied-dim? natural?)]
-  [fin-multiplied-dim-original (-> fin-multiplied-dim? any/c)]
-  [fin-multiplied-dim/c
-    (-> exact-positive-integer? contract? contract?)]
-  [fin-multiplied-dim=?
-    (-> (-> any/c any/c boolean?) any/c any/c boolean?)])
+(provide #/own-contract-out
+  fin-multiplied-dim?
+  fin-multiplied-dim-index
+  fin-multiplied-dim-original
+  fin-multiplied-dim/c
+  fin-multiplied-dim=?)
 (provide
   fin-multiplied-dim-sys)
-(provide #/shim-contract-out
-  [fin-multiplied-dim-sys? (-> any/c boolean?)]
-  [fin-multiplied-dim-sys-bound
-    (-> fin-multiplied-dim-sys? exact-positive-integer?)]
-  [fin-multiplied-dim-sys-original
-    (-> fin-multiplied-dim-sys? dim-sys?)])
+(provide #/own-contract-out
+  fin-multiplied-dim-sys?
+  fin-multiplied-dim-sys-bound
+  fin-multiplied-dim-sys-original)
 (provide
   fin-multiplied-dim-sys-morphism-sys)
-(provide #/shim-contract-out
-  [fin-multiplied-dim-sys-morphism-sys? (-> any/c boolean?)]
-  [fin-multiplied-dim-sys-morphism-sys-bound
-    (-> fin-multiplied-dim-sys-morphism-sys? exact-positive-integer?)]
-  [fin-multiplied-dim-sys-morphism-sys-original
-    (-> fin-multiplied-dim-sys-morphism-sys?
-      dim-sys-morphism-sys?)])
+(provide #/own-contract-out
+  fin-multiplied-dim-sys-morphism-sys?
+  fin-multiplied-dim-sys-morphism-sys-bound
+  fin-multiplied-dim-sys-morphism-sys-original)
 (provide
   fin-multiplied-dim-sys-endofunctor-sys)
-(provide #/shim-contract-out
-  [fin-multiplied-dim-sys-endofunctor-sys? (-> any/c boolean?)]
-  [fin-multiplied-dim-sys-endofunctor-sys-bound
-    (-> fin-multiplied-dim-sys-endofunctor-sys?
-      exact-positive-integer?)])
+(provide #/own-contract-out
+  fin-multiplied-dim-sys-endofunctor-sys?
+  fin-multiplied-dim-sys-endofunctor-sys-bound)
 (provide
   fin-times-dim-sys-morphism-sys)
-(provide #/shim-contract-out
-  [fin-times-dim-sys-morphism-sys? (-> any/c boolean?)]
-  [fin-times-dim-sys-morphism-sys-bound
-    (-> fin-times-dim-sys-morphism-sys? exact-positive-integer?)]
-  [fin-times-dim-sys-morphism-sys-source
-    (-> fin-times-dim-sys-morphism-sys? dim-sys?)]
-  [fin-times-dim-sys-morphism-sys-dim-to-index
-    (->i ([ms fin-times-dim-sys-morphism-sys?])
-      [_ (ms)
-        (-> (dim-sys-dim/c #/fin-times-dim-sys-morphism-sys-source ms)
-          (and/c natural?
-            (</c #/fin-times-dim-sys-morphism-sys-bound ms)))])])
+(provide #/own-contract-out
+  fin-times-dim-sys-morphism-sys?
+  fin-times-dim-sys-morphism-sys-bound
+  fin-times-dim-sys-morphism-sys-source
+  fin-times-dim-sys-morphism-sys-dim-to-index)
 (provide
   fin-untimes-dim-sys-morphism-sys)
-(provide #/shim-contract-out
-  [fin-untimes-dim-sys-morphism-sys? (-> any/c boolean?)]
-  [fin-untimes-dim-sys-morphism-sys-bound
-    (-> fin-untimes-dim-sys-morphism-sys? exact-positive-integer?)]
-  [fin-untimes-dim-sys-morphism-sys-target
-    (-> fin-untimes-dim-sys-morphism-sys? dim-sys?)])
+(provide #/own-contract-out
+  fin-untimes-dim-sys-morphism-sys?
+  fin-untimes-dim-sys-morphism-sys-bound
+  fin-untimes-dim-sys-morphism-sys-target)
 (provide
   fin-multiplied-dim-successors-sys)
-(provide #/shim-contract-out
-  [fin-multiplied-dim-successors-sys? (-> any/c boolean?)]
-  [fin-multiplied-dim-successors-sys-bound
-    (-> fin-multiplied-dim-successors-sys? exact-positive-integer?)]
-  [fin-multiplied-dim-successors-sys-original
-    (-> fin-multiplied-dim-successors-sys? dim-successors-sys?)])
+(provide #/own-contract-out
+  fin-multiplied-dim-successors-sys?
+  fin-multiplied-dim-successors-sys-bound
+  fin-multiplied-dim-successors-sys-original)
 |#
 
 
@@ -662,31 +554,71 @@
       ; category-sys-morphism-chain-two
       (fn cs a b c ab bc
         (dim-sys-morphism-sys-chain-two ab bc)))))
+(ascribe-own-contract dim-sys-category-sys? (-> any/c boolean?))
 
-(define (functor-from-dim-sys-sys-apply-to-morphism fs dsms)
+(define/own-contract
+  (functor-from-dim-sys-sys-apply-to-morphism fs dsms)
+  (->i
+    (
+      [fs (functor-sys/c dim-sys-category-sys? any/c)]
+      [dsms dim-sys-morphism-sys?])
+    [_ (fs dsms)
+      (category-sys-morphism/c (functor-sys-target fs)
+        (functor-sys-apply-to-object fs
+          (dim-sys-morphism-sys-source dsms))
+        (functor-sys-apply-to-object fs
+          (dim-sys-morphism-sys-target dsms)))])
   (functor-sys-apply-to-morphism fs
     (dim-sys-morphism-sys-source dsms)
     (dim-sys-morphism-sys-target dsms)
     dsms))
 
-(define
+(define/own-contract
   (natural-transformation-from-from-dim-sys-sys-apply-to-morphism
     nts dsms)
+  (->i
+    (
+      [nts
+        (natural-transformation-sys/c
+          dim-sys-category-sys? any/c any/c any/c)]
+      [dsms dim-sys-morphism-sys?])
+    [_ (nts dsms)
+      (category-sys-morphism/c
+        (natural-transformation-sys-endpoint-target nts)
+        (functor-sys-apply-to-object
+          (natural-transformation-sys-source nts)
+          (dim-sys-morphism-sys-source dsms))
+        (functor-sys-apply-to-object
+          (natural-transformation-sys-target nts)
+          (dim-sys-morphism-sys-target dsms)))])
   (natural-transformation-sys-apply-to-morphism nts
     (dim-sys-morphism-sys-source dsms)
     (dim-sys-morphism-sys-target dsms)
     dsms))
 
-(define (dim-sys-endofunctor-sys? v)
+(define/own-contract (dim-sys-endofunctor-sys? v)
+  (-> any/c boolean?)
   (
     (flat-contract-predicate
       (functor-sys/c dim-sys-category-sys? dim-sys-category-sys?))
     v))
 
-(define
+(define/own-contract
   (make-dim-sys-endofunctor-sys-impl-from-apply
     apply-to-dim-sys
     apply-to-dim-sys-morphism-sys)
+  (->
+    (-> dim-sys-endofunctor-sys? dim-sys? dim-sys?)
+    (->i ([es dim-sys-endofunctor-sys?] [ms dim-sys-morphism-sys?])
+      [_ (es ms)
+        (dim-sys-morphism-sys/c
+          (ok/c
+            (functor-sys-apply-to-object es
+              (dim-sys-morphism-sys-source ms)))
+          (ok/c
+            (functor-sys-apply-to-object es
+              (dim-sys-morphism-sys-target ms))))])
+    functor-sys-impl?)
   (make-functor-sys-impl-from-apply
     ; functor-sys-source
     (fn fs #/dim-sys-category-sys)
@@ -723,12 +655,51 @@
   prop:dim-successors-sys
   make-dim-successors-sys-impl-from-dim-plus-int
   'dim-successors-sys 'dim-successors-sys-impl (list))
+(ascribe-own-contract dim-successors-sys? (-> any/c boolean?))
+(ascribe-own-contract dim-successors-sys-impl? (-> any/c boolean?))
+(ascribe-own-contract dim-successors-sys-dim-sys
+  (-> dim-successors-sys? dim-sys?))
+(ascribe-own-contract dim-successors-sys-dim-plus-int
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [d (dss) (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
+      [n exact-integer?])
+    [_ (dss)
+      (maybe/c #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]))
+(ascribe-own-contract prop:dim-successors-sys
+  (struct-type-property/c dim-successors-sys-impl?))
+(ascribe-own-contract make-dim-successors-sys-impl-from-dim-plus-int
+  (->
+    (-> dim-successors-sys? dim-sys?)
+    (->i
+      (
+        [dss dim-successors-sys?]
+        [d (dss)
+          (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
+        [n exact-integer?])
+      [_ (dss n)
+        (maybe/c
+        #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])
+    dim-successors-sys-impl?))
 
-(define (dim-successors-sys-dim-from-int dss n)
+(define/own-contract (dim-successors-sys-dim-from-int dss n)
+  (->i ([dss dim-successors-sys?] [n exact-integer?])
+    [_ (dss)
+      (maybe/c #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])
   (w- ds (dim-successors-sys-dim-sys dss)
   #/dim-successors-sys-dim-plus-int dss (dim-sys-dim-zero ds) n))
 
-(define (dim-successors-sys-dim=plus-int? dss candidate d n)
+(define/own-contract
+  (dim-successors-sys-dim=plus-int? dss candidate d n)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [candidate (dss)
+        (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
+      [d (dss) (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
+      [n exact-integer?])
+    [_ boolean?])
   (w- ds (dim-successors-sys-dim-sys dss)
   #/expect (dim-successors-sys-dim-plus-int dss d n) (just result) #f
   #/dim-sys-dim=? ds candidate result))
@@ -754,6 +725,8 @@
       (fn dss d n
         (mat n 0 (just d)
         #/nothing)))))
+(ascribe-own-contract successorless-dim-successors-sys?
+  (-> any/c boolean?))
 
 (define-imitation-simple-struct (nat-dim-sys?) nat-dim-sys
   'nat-dim-sys (current-inspector) (auto-write) (auto-equal)
@@ -770,6 +743,7 @@
     (fn ds 0)
     ; dim-sys-dim-max-of-two
     (fn ds a b #/max a b)))
+(ascribe-own-contract nat-dim-sys? (-> any/c boolean?))
 (define-imitation-simple-struct (nat-dim-successors-sys?)
   nat-dim-successors-sys 'nat-dim-successors-sys (current-inspector)
   (auto-write)
@@ -787,6 +761,7 @@
         (w- result (+ d n)
         #/if (< result 0) (nothing)
         #/just result)))))
+(ascribe-own-contract nat-dim-successors-sys? (-> any/c boolean?))
 
 
 (define-imitation-simple-struct
@@ -796,16 +771,24 @@
   'extended-with-top-dim-finite (current-inspector)
   (auto-write)
   (auto-equal))
+(ascribe-own-contract extended-with-top-dim-finite?
+  (-> any/c boolean?))
+(ascribe-own-contract extended-with-top-dim-finite-original
+  (-> extended-with-top-dim-finite? any/c))
 (define-imitation-simple-struct (extended-with-top-dim-infinite?)
   extended-with-top-dim-infinite
   'extended-with-top-dim-infinite (current-inspector)
   (auto-write)
   (auto-equal))
-(define (extended-with-top-dim? v)
+(ascribe-own-contract extended-with-top-dim-infinite?
+  (-> any/c boolean?))
+(define/own-contract (extended-with-top-dim? v)
+  (-> any/c boolean?)
   (or
     (extended-with-top-dim-finite? v)
     (extended-with-top-dim-infinite? v)))
-(define (extended-with-top-dim/c original-dim/c)
+(define/own-contract (extended-with-top-dim/c original-dim/c)
+  (-> contract? contract?)
   (w- original-dim/c
     (coerce-contract 'extended-with-top-dim/c original-dim/c)
   #/rename-contract
@@ -813,7 +796,12 @@
       (match/c extended-with-top-dim-finite original-dim/c)
       extended-with-top-dim-infinite?)
     `(extended-with-top-dim/c ,(contract-name original-dim/c))))
-(define (extended-with-top-dim=? original-dim=? a b)
+(define/own-contract (extended-with-top-dim=? original-dim=? a b)
+  (->
+    (-> any/c any/c boolean?)
+    extended-with-top-dim?
+    extended-with-top-dim?
+    boolean?)
   (mat a (extended-with-top-dim-finite orig-a)
     (expect b (extended-with-top-dim-finite orig-b) #f
     #/original-dim=? orig-a orig-b)
@@ -851,6 +839,9 @@
       #/expect b (extended-with-top-dim-finite orig-b) b
       #/extended-with-top-dim-finite
         (dim-sys-dim-max-of-two orig-ds orig-a orig-b)))))
+(ascribe-own-contract extended-with-top-dim-sys? (-> any/c boolean?))
+(ascribe-own-contract extended-with-top-dim-sys-original
+  (-> extended-with-top-dim-sys? dim-sys?))
 (define-match-expander-attenuated
   attenuated-extended-with-top-dim-sys
   unguarded-extended-with-top-dim-sys
@@ -919,6 +910,10 @@
           (extended-with-top-dim-infinite)
         #/extended-with-top-dim-finite
           (dim-sys-morphism-sys-morph-dim orig d))))))
+(ascribe-own-contract extended-with-top-dim-sys-morphism-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract extended-with-top-dim-sys-morphism-sys-original
+  (-> extended-with-top-dim-sys-morphism-sys? dim-sys-morphism-sys?))
 (define-match-expander-attenuated
   attenuated-extended-with-top-dim-sys-morphism-sys
   unguarded-extended-with-top-dim-sys-morphism-sys
@@ -943,6 +938,8 @@
     (make-dim-sys-endofunctor-sys-impl-from-apply
       (fn es ds #/extended-with-top-dim-sys ds)
       (fn es ms #/extended-with-top-dim-sys-morphism-sys ms))))
+(ascribe-own-contract extended-with-top-dim-sys-endofunctor-sys?
+  (-> any/c boolean?))
 (define-imitation-simple-struct
   (extend-with-top-dim-sys-morphism-sys?
     extend-with-top-dim-sys-morphism-sys-source)
@@ -981,6 +978,10 @@
         #/extend-with-top-dim-sys-morphism-sys new-s))
       ; dim-sys-morphism-sys-morph-dim
       (fn ms d #/extended-with-top-dim-finite d))))
+(ascribe-own-contract extend-with-top-dim-sys-morphism-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract extend-with-top-dim-sys-morphism-sys-source
+  (-> extend-with-top-dim-sys-morphism-sys? dim-sys?))
 (define-match-expander-attenuated
   attenuated-extend-with-top-dim-sys-morphism-sys
   unguarded-extend-with-top-dim-sys-morphism-sys
@@ -1024,6 +1025,10 @@
       #/dissect b (extended-with-top-dim-finite orig-b)
       #/extended-with-top-dim-finite
         (dim-sys-dim-max-of-two orig-ds orig-a orig-b)))))
+(ascribe-own-contract extended-with-top-finite-dim-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract extended-with-top-finite-dim-sys-original
+  (-> extended-with-top-finite-dim-sys? dim-sys?))
 (define-match-expander-attenuated
   attenuated-extended-with-top-finite-dim-sys
   unguarded-extended-with-top-finite-dim-sys
@@ -1074,6 +1079,10 @@
       (fn ms d
         (dissect d (extended-with-top-dim-finite d)
           d)))))
+(ascribe-own-contract unextend-with-top-dim-sys-morphism-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract unextend-with-top-dim-sys-morphism-sys-target
+  (-> unextend-with-top-dim-sys-morphism-sys? dim-sys?))
 (define-match-expander-attenuated
   attenuated-unextend-with-top-dim-sys-morphism-sys
   unguarded-unextend-with-top-dim-sys-morphism-sys
@@ -1122,6 +1131,10 @@
           (dim-successors-sys-dim-plus-int orig-dss orig-d n)
         #/fn result
           (extended-with-top-dim-finite result))))))
+(ascribe-own-contract extended-with-top-dim-successors-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract extended-with-top-dim-successors-sys-original
+  (-> extended-with-top-dim-successors-sys? dim-successors-sys?))
 (define-match-expander-attenuated
   attenuated-extended-with-top-dim-successors-sys
   unguarded-extended-with-top-dim-successors-sys
@@ -1168,6 +1181,11 @@
   unguarded-fin-multiplied-dim 'fin-multiplied-dim (current-inspector)
   (auto-write)
   (auto-equal))
+(ascribe-own-contract fin-multiplied-dim? (-> any/c boolean?))
+(ascribe-own-contract fin-multiplied-dim-index
+  (-> fin-multiplied-dim? natural?))
+(ascribe-own-contract fin-multiplied-dim-original
+  (-> fin-multiplied-dim? any/c))
 (define-match-expander-attenuated
   attenuated-fin-multiplied-dim
   unguarded-fin-multiplied-dim
@@ -1179,7 +1197,8 @@
   unguarded-fin-multiplied-dim
   attenuated-fin-multiplied-dim
   attenuated-fin-multiplied-dim)
-(define (fin-multiplied-dim/c bound original-dim/c)
+(define/own-contract (fin-multiplied-dim/c bound original-dim/c)
+  (-> exact-positive-integer? contract? contract?)
   (w- original-dim/c
     (coerce-contract 'fin-multiplied-dim/c original-dim/c)
   #/rename-contract
@@ -1187,7 +1206,8 @@
       (and/c natural? #/</c bound)
       original-dim/c)
     `(fin-multiplied-dim/c ,bound ,(contract-name original-dim/c))))
-(define (fin-multiplied-dim=? original-dim=? a b)
+(define/own-contract (fin-multiplied-dim=? original-dim=? a b)
+  (-> (-> any/c any/c boolean?) any/c any/c boolean?)
   (dissect a (fin-multiplied-dim a-i a-orig)
   #/dissect b (fin-multiplied-dim b-i b-orig)
   
@@ -1232,6 +1252,11 @@
       #/expect (dim-sys-dim=? orig-ds max-orig b-orig) #t
         a
       #/fin-multiplied-dim (max a-i b-i) max-orig))))
+(ascribe-own-contract fin-multiplied-dim-sys? (-> any/c boolean?))
+(ascribe-own-contract fin-multiplied-dim-sys-bound
+  (-> fin-multiplied-dim-sys? exact-positive-integer?))
+(ascribe-own-contract fin-multiplied-dim-sys-original
+  (-> fin-multiplied-dim-sys? dim-sys?))
 (define-match-expander-attenuated
   attenuated-fin-multiplied-dim-sys
   unguarded-fin-multiplied-dim-sys
@@ -1324,6 +1349,12 @@
         #/dissect d (fin-multiplied-dim i d)
         #/fin-multiplied-dim i
           (dim-sys-morphism-sys-morph-dim orig d))))))
+(ascribe-own-contract fin-multiplied-dim-sys-morphism-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract fin-multiplied-dim-sys-morphism-sys-bound
+  (-> fin-multiplied-dim-sys-morphism-sys? exact-positive-integer?))
+(ascribe-own-contract fin-multiplied-dim-sys-morphism-sys-original
+  (-> fin-multiplied-dim-sys-morphism-sys? dim-sys-morphism-sys?))
 (define-match-expander-attenuated
   attenuated-fin-multiplied-dim-sys-morphism-sys
   unguarded-fin-multiplied-dim-sys-morphism-sys
@@ -1356,6 +1387,11 @@
       (fn es ms
         (dissect es (fin-multiplied-dim-sys-endofunctor-sys bound)
         #/fin-multiplied-dim-sys bound ms)))))
+(ascribe-own-contract fin-multiplied-dim-sys-endofunctor-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract fin-multiplied-dim-sys-endofunctor-sys-bound
+  (-> fin-multiplied-dim-sys-endofunctor-sys?
+    exact-positive-integer?))
 (define-match-expander-attenuated
   attenuated-fin-multiplied-dim-sys-endofunctor-sys
   unguarded-fin-multiplied-dim-sys-endofunctor-sys
@@ -1419,6 +1455,18 @@
       (fn ms d
         (dissect ms (fin-times-dim-sys-morphism-sys bound source d->i)
         #/fin-multiplied-dim (d->i d) d)))))
+(ascribe-own-contract fin-times-dim-sys-morphism-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract fin-times-dim-sys-morphism-sys-bound
+  (-> fin-times-dim-sys-morphism-sys? exact-positive-integer?))
+(ascribe-own-contract fin-times-dim-sys-morphism-sys-source
+  (-> fin-times-dim-sys-morphism-sys? dim-sys?))
+(ascribe-own-contract fin-times-dim-sys-morphism-sys-dim-to-index
+  (->i ([ms fin-times-dim-sys-morphism-sys?])
+    [_ (ms)
+      (-> (dim-sys-dim/c #/fin-times-dim-sys-morphism-sys-source ms)
+        (and/c natural?
+          (</c #/fin-times-dim-sys-morphism-sys-bound ms)))]))
 ; TODO: We have a dilemma. The `define/contract` version of
 ; `attenuated-fin-times-dim-sys-morphism-sys` will give less precise
 ; source location information in its errors, and it won't catch
@@ -1508,6 +1556,12 @@
       (fn ms d
         (dissect d (fin-multiplied-dim i d)
           d)))))
+(ascribe-own-contract fin-untimes-dim-sys-morphism-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract fin-untimes-dim-sys-morphism-sys-bound
+  (-> fin-untimes-dim-sys-morphism-sys? exact-positive-integer?))
+(ascribe-own-contract fin-untimes-dim-sys-morphism-sys-target
+  (-> fin-untimes-dim-sys-morphism-sys? dim-sys?))
 (define-match-expander-attenuated
   attenuated-fin-untimes-dim-sys-morphism-sys
   unguarded-fin-untimes-dim-sys-morphism-sys
@@ -1561,6 +1615,12 @@
             orig-dss orig-d n-to-add-to-orig)
         #/fn orig-result
           (fin-multiplied-dim i orig-result))))))
+(ascribe-own-contract fin-multiplied-dim-successors-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract fin-multiplied-dim-successors-sys-bound
+  (-> fin-multiplied-dim-successors-sys? exact-positive-integer?))
+(ascribe-own-contract fin-multiplied-dim-successors-sys-original
+  (-> fin-multiplied-dim-successors-sys? dim-successors-sys?))
 (define-match-expander-attenuated
   attenuated-fin-multiplied-dim-successors-sys
   unguarded-fin-multiplied-dim-successors-sys

--- a/punctaffy-lib/hypersnippet/dim.rkt
+++ b/punctaffy-lib/hypersnippet/dim.rkt
@@ -5,7 +5,7 @@
 ; Interfaces to represent numbers that represent the dimensionality of
 ; hypersnippets.
 
-;   Copyright 2019, 2020 The Lathe Authors
+;   Copyright 2019, 2020, 2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -62,117 +62,44 @@
   make-atomic-set-element-sys-impl-from-contract ok/c
   prop:atomic-set-element-sys)
 
+; TODO NOW: Remove uses of `lathe-morphisms/private/shim`,
+; particularly including `shim-contract-out` and
+; `shim-recontract-out`.
 (require lathe-morphisms/private/shim)
+(require punctaffy/private/shim)
+(shim-init)
 
 
-(provide #/shim-contract-out
+(provide #/own-contract-out
   
-  [dim-sys? (-> any/c boolean?)]
-  [dim-sys-impl? (-> any/c boolean?)]
-  [dim-sys-dim/c (-> dim-sys? flat-contract?)]
-  [dim-sys-dim-max
-    (->i ([ds dim-sys?])
-      #:rest [args (ds) (listof #/dim-sys-dim/c ds)]
-      [_ (ds) (dim-sys-dim/c ds)])]
-  [dim-sys-dim-zero (->i ([ds dim-sys?]) [_ (ds) (dim-sys-dim/c ds)])]
-  [dim-sys-dim-max-of-two
-    (->i
-      (
-        [ds dim-sys?]
-        [a (ds) (dim-sys-dim/c ds)]
-        [b (ds) (dim-sys-dim/c ds)])
-      [_ (ds) (dim-sys-dim/c ds)])]
-  [dim-sys-dim=?
-    (->i
-      (
-        [ds dim-sys?]
-        [a (ds) (dim-sys-dim/c ds)]
-        [b (ds) (dim-sys-dim/c ds)])
-      [_ boolean?])]
-  [dim-sys-dim<=?
-    (->i
-      (
-        [ds dim-sys?]
-        [a (ds) (dim-sys-dim/c ds)]
-        [b (ds) (dim-sys-dim/c ds)])
-      [_ boolean?])]
-  [dim-sys-dim<?
-    (->i
-      (
-        [ds dim-sys?]
-        [a (ds) (dim-sys-dim/c ds)]
-        [b (ds) (dim-sys-dim/c ds)])
-      [_ boolean?])]
-  [dim-sys-dim</c
-    (->i ([ds dim-sys?] [bound (ds) (dim-sys-dim/c ds)])
-      [_ flat-contract?])]
-  [dim-sys-dim=/c
-    (->i ([ds dim-sys?] [bound (ds) (dim-sys-dim/c ds)])
-      [_ flat-contract?])]
-  [dim-sys-dim=0?
-    (->i ([ds dim-sys?] [d (ds) (dim-sys-dim/c ds)]) [_ boolean?])]
-  [dim-sys-0<dim/c (-> dim-sys? flat-contract?)]
-  [prop:dim-sys (struct-type-property/c dim-sys-impl?)]
-  [make-dim-sys-impl-from-max-of-two
-    (->
-      (-> dim-sys? flat-contract?)
-      (->i
-        (
-          [ds dim-sys?]
-          [a (ds) (dim-sys-dim/c ds)]
-          [b (ds) (dim-sys-dim/c ds)])
-        [_ boolean?])
-      (->i ([ds dim-sys?]) [_ (ds) (dim-sys-dim/c ds)])
-      (->i
-        (
-          [ds dim-sys?]
-          [a (ds) (dim-sys-dim/c ds)]
-          [b (ds) (dim-sys-dim/c ds)])
-        [_ (ds) (dim-sys-dim/c ds)])
-      dim-sys-impl?)]
+  dim-sys?
+  dim-sys-impl?
+  dim-sys-dim/c
+  dim-sys-dim-max
+  dim-sys-dim-zero
+  dim-sys-dim-max-of-two
+  dim-sys-dim=?
+  dim-sys-dim<=?
+  dim-sys-dim<?
+  dim-sys-dim</c
+  dim-sys-dim=/c
+  dim-sys-dim=0?
+  dim-sys-0<dim/c
+  prop:dim-sys
+  make-dim-sys-impl-from-max-of-two
   
-  [dim-sys-morphism-sys? (-> any/c boolean?)]
-  [dim-sys-morphism-sys-impl? (-> any/c boolean?)]
-  [dim-sys-morphism-sys-source (-> dim-sys-morphism-sys? dim-sys?)]
-  [dim-sys-morphism-sys-replace-source
-    (-> dim-sys-morphism-sys? dim-sys? dim-sys-morphism-sys?)]
-  [dim-sys-morphism-sys-target (-> dim-sys-morphism-sys? dim-sys?)]
-  [dim-sys-morphism-sys-replace-target
-    (-> dim-sys-morphism-sys? dim-sys? dim-sys-morphism-sys?)]
-  [dim-sys-morphism-sys-morph-dim
-    (->i
-      (
-        [ms dim-sys-morphism-sys?]
-        [d (ms) (dim-sys-dim/c #/dim-sys-morphism-sys-source ms)])
-      [_ (ms) (dim-sys-dim/c #/dim-sys-morphism-sys-target ms)])]
-  [dim-sys-morphism-sys/c (-> contract? contract? contract?)]
-  [prop:dim-sys-morphism-sys
-    (struct-type-property/c dim-sys-morphism-sys-impl?)]
-  [make-dim-sys-morphism-sys-impl-from-morph
-    (->
-      (-> dim-sys-morphism-sys? dim-sys?)
-      (-> dim-sys-morphism-sys? dim-sys? dim-sys-morphism-sys?)
-      (-> dim-sys-morphism-sys? dim-sys?)
-      (-> dim-sys-morphism-sys? dim-sys? dim-sys-morphism-sys?)
-      (->i
-        (
-          [ms dim-sys-morphism-sys?]
-          [d (ms) (dim-sys-dim/c #/dim-sys-morphism-sys-source ms)])
-        [_ (ms) (dim-sys-dim/c #/dim-sys-morphism-sys-target ms)])
-      dim-sys-morphism-sys-impl?)]
-  [dim-sys-morphism-sys-identity (-> dim-sys? dim-sys-morphism-sys?)]
-  [dim-sys-morphism-sys-chain-two
-    (->i
-      (
-        [ab dim-sys-morphism-sys?]
-        [bc (ab)
-          (dim-sys-morphism-sys/c
-            (ok/c #/dim-sys-morphism-sys-target ab)
-            any/c)])
-      [_ (ab bc)
-        (dim-sys-morphism-sys/c
-          (ok/c #/dim-sys-morphism-sys-source ab)
-          (ok/c #/dim-sys-morphism-sys-target bc))])])
+  dim-sys-morphism-sys?
+  dim-sys-morphism-sys-impl?
+  dim-sys-morphism-sys-source
+  dim-sys-morphism-sys-replace-source
+  dim-sys-morphism-sys-target
+  dim-sys-morphism-sys-replace-target
+  dim-sys-morphism-sys-morph-dim
+  dim-sys-morphism-sys/c
+  prop:dim-sys-morphism-sys
+  make-dim-sys-morphism-sys-impl-from-morph
+  dim-sys-morphism-sys-identity
+  dim-sys-morphism-sys-chain-two)
 
 (provide
   dim-sys-category-sys)
@@ -421,6 +348,44 @@
   (#:method dim-sys-dim-max-of-two (#:this) () ())
   prop:dim-sys make-dim-sys-impl-from-max-of-two
   'dim-sys 'dim-sys-impl (list))
+(ascribe-own-contract dim-sys? (-> any/c boolean?))
+(ascribe-own-contract dim-sys-impl? (-> any/c boolean?))
+(ascribe-own-contract dim-sys-dim/c (-> dim-sys? flat-contract?))
+(ascribe-own-contract dim-sys-dim=?
+  (->i
+    (
+      [ds dim-sys?]
+      [a (ds) (dim-sys-dim/c ds)]
+      [b (ds) (dim-sys-dim/c ds)])
+    [_ boolean?]))
+(ascribe-own-contract dim-sys-dim-zero
+  (->i ([ds dim-sys?]) [_ (ds) (dim-sys-dim/c ds)]))
+(ascribe-own-contract dim-sys-dim-max-of-two
+  (->i
+    (
+      [ds dim-sys?]
+      [a (ds) (dim-sys-dim/c ds)]
+      [b (ds) (dim-sys-dim/c ds)])
+    [_ (ds) (dim-sys-dim/c ds)]))
+(ascribe-own-contract prop:dim-sys
+  (struct-type-property/c dim-sys-impl?))
+(ascribe-own-contract make-dim-sys-impl-from-max-of-two
+  (->
+    (-> dim-sys? flat-contract?)
+    (->i
+      (
+        [ds dim-sys?]
+        [a (ds) (dim-sys-dim/c ds)]
+        [b (ds) (dim-sys-dim/c ds)])
+      [_ boolean?])
+    (->i ([ds dim-sys?]) [_ (ds) (dim-sys-dim/c ds)])
+    (->i
+      (
+        [ds dim-sys?]
+        [a (ds) (dim-sys-dim/c ds)]
+        [b (ds) (dim-sys-dim/c ds)])
+      [_ (ds) (dim-sys-dim/c ds)])
+    dim-sys-impl?))
 
 (define (dim-sys-dim-max-of-dim-and-list ds d lst)
   (expect lst (cons first rest)
@@ -434,32 +399,52 @@
 
 ; NOTE OPTIMIZATION: The use of `case-lambda` gives this a substantial
 ; boost.
-(define dim-sys-dim-max
+(define/own-contract dim-sys-dim-max
+  (->i ([ds dim-sys?]) #:rest [args (ds) (listof #/dim-sys-dim/c ds)]
+    [_ (ds) (dim-sys-dim/c ds)])
   (case-lambda
     [(ds a b) (dim-sys-dim-max-of-two ds a b)]
     [(ds) (dim-sys-dim-zero ds)]
     [(ds d . args) (dim-sys-dim-max-of-dim-and-list ds d args)]))
 
-(define (dim-sys-dim<=? ds a b)
+(define/own-contract (dim-sys-dim<=? ds a b)
+  (->i
+    (
+      [ds dim-sys?]
+      [a (ds) (dim-sys-dim/c ds)]
+      [b (ds) (dim-sys-dim/c ds)])
+    [_ boolean?])
   (dim-sys-dim=? ds b #/dim-sys-dim-max ds a b))
 
-(define (dim-sys-dim<? ds a b)
+(define/own-contract (dim-sys-dim<? ds a b)
+  (->i
+    (
+      [ds dim-sys?]
+      [a (ds) (dim-sys-dim/c ds)]
+      [b (ds) (dim-sys-dim/c ds)])
+    [_ boolean?])
   (and (not #/dim-sys-dim=? ds a b) (dim-sys-dim<=? ds a b)))
 
-(define (dim-sys-dim</c ds bound)
+(define/own-contract (dim-sys-dim</c ds bound)
+  (->i ([ds dim-sys?] [bound (ds) (dim-sys-dim/c ds)])
+    [_ flat-contract?])
   (rename-contract
     (and/c (dim-sys-dim/c ds) (fn v #/dim-sys-dim<? ds v bound))
     `(dim-sys-dim</c ,ds ,bound)))
 
-(define (dim-sys-dim=/c ds bound)
+(define/own-contract (dim-sys-dim=/c ds bound)
+  (->i ([ds dim-sys?] [bound (ds) (dim-sys-dim/c ds)])
+    [_ flat-contract?])
   (rename-contract
     (and/c (dim-sys-dim/c ds) (fn v #/dim-sys-dim=? ds v bound))
     `(dim-sys-dim=/c ,ds ,bound)))
 
-(define (dim-sys-dim=0? ds d)
+(define/own-contract (dim-sys-dim=0? ds d)
+  (->i ([ds dim-sys?] [d (ds) (dim-sys-dim/c ds)]) [_ boolean?])
   (dim-sys-dim=? ds (dim-sys-dim-zero ds) d))
 
-(define (dim-sys-0<dim/c ds)
+(define/own-contract (dim-sys-0<dim/c ds)
+  (-> dim-sys? flat-contract?)
   (rename-contract
     (and/c (dim-sys-dim/c ds) (fn v #/not #/dim-sys-dim=0? ds v))
     `(dim-sys-0<dim/c ,ds)))
@@ -474,8 +459,39 @@
   (#:method dim-sys-morphism-sys-morph-dim (#:this) ())
   prop:dim-sys-morphism-sys make-dim-sys-morphism-sys-impl-from-morph
   'dim-sys-morphism-sys 'dim-sys-morphism-sys-impl (list))
+(ascribe-own-contract dim-sys-morphism-sys? (-> any/c boolean?))
+(ascribe-own-contract dim-sys-morphism-sys-impl? (-> any/c boolean?))
+(ascribe-own-contract dim-sys-morphism-sys-source
+  (-> dim-sys-morphism-sys? dim-sys?))
+(ascribe-own-contract dim-sys-morphism-sys-replace-source
+  (-> dim-sys-morphism-sys? dim-sys? dim-sys-morphism-sys?))
+(ascribe-own-contract dim-sys-morphism-sys-target
+  (-> dim-sys-morphism-sys? dim-sys?))
+(ascribe-own-contract dim-sys-morphism-sys-replace-target
+  (-> dim-sys-morphism-sys? dim-sys? dim-sys-morphism-sys?))
+(ascribe-own-contract dim-sys-morphism-sys-morph-dim
+  (->i
+    (
+      [ms dim-sys-morphism-sys?]
+      [d (ms) (dim-sys-dim/c #/dim-sys-morphism-sys-source ms)])
+    [_ (ms) (dim-sys-dim/c #/dim-sys-morphism-sys-target ms)]))
+(ascribe-own-contract prop:dim-sys-morphism-sys
+  (struct-type-property/c dim-sys-morphism-sys-impl?))
+(ascribe-own-contract make-dim-sys-morphism-sys-impl-from-morph
+  (->
+    (-> dim-sys-morphism-sys? dim-sys?)
+    (-> dim-sys-morphism-sys? dim-sys? dim-sys-morphism-sys?)
+    (-> dim-sys-morphism-sys? dim-sys?)
+    (-> dim-sys-morphism-sys? dim-sys? dim-sys-morphism-sys?)
+    (->i
+      (
+        [ms dim-sys-morphism-sys?]
+        [d (ms) (dim-sys-dim/c #/dim-sys-morphism-sys-source ms)])
+      [_ (ms) (dim-sys-dim/c #/dim-sys-morphism-sys-target ms)])
+    dim-sys-morphism-sys-impl?))
 
-(define (dim-sys-morphism-sys/c source/c target/c)
+(define/own-contract (dim-sys-morphism-sys/c source/c target/c)
+  (-> contract? contract? contract?)
   (w- source/c (coerce-contract 'dim-sys-morphism-sys/c source/c)
   #/w- target/c (coerce-contract 'dim-sys-morphism-sys/c target/c)
   #/w- name
@@ -556,7 +572,8 @@
       ; dim-sys-morphism-sys-morph-dim
       (fn ms d d))))
 
-(define (dim-sys-morphism-sys-identity endpoint)
+(define/own-contract (dim-sys-morphism-sys-identity endpoint)
+  (-> dim-sys? dim-sys-morphism-sys?)
   (identity-dim-sys-morphism-sys endpoint))
 
 (define-imitation-simple-struct
@@ -600,7 +617,18 @@
         #/dim-sys-morphism-sys-morph-dim bc
           (dim-sys-morphism-sys-morph-dim ab d))))))
 
-(define (dim-sys-morphism-sys-chain-two ab bc)
+(define/own-contract (dim-sys-morphism-sys-chain-two ab bc)
+  (->i
+    (
+      [ab dim-sys-morphism-sys?]
+      [bc (ab)
+        (dim-sys-morphism-sys/c
+          (ok/c #/dim-sys-morphism-sys-target ab)
+          any/c)])
+    [_ (ab bc)
+      (dim-sys-morphism-sys/c
+        (ok/c #/dim-sys-morphism-sys-source ab)
+        (ok/c #/dim-sys-morphism-sys-target bc))])
   (chain-two-dim-sys-morphism-sys ab bc))
 
 

--- a/punctaffy-lib/hypersnippet/dim.rkt
+++ b/punctaffy-lib/hypersnippet/dim.rkt
@@ -67,7 +67,7 @@
 ; `shim-recontract-out`.
 (require lathe-morphisms/private/shim)
 (require punctaffy/private/shim)
-(shim-init)
+(init-shim)
 
 
 (provide #/own-contract-out

--- a/punctaffy-lib/hypersnippet/hypernest.rkt
+++ b/punctaffy-lib/hypersnippet/hypernest.rkt
@@ -5,7 +5,7 @@
 ; A data structure for encoding hypersnippet notations that can nest
 ; with themselves.
 
-;   Copyright 2018-2021 The Lathe Authors
+;   Copyright 2018-2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@
 ;   language governing permissions and limitations under the License.
 
 
+; TODO NOW: Remove uses of `lathe-morphisms/private/shim`,
+; particularly including `shim-contract-out` and
+; `shim-recontract-out`.
 (require lathe-morphisms/private/shim)
 
 (require #/submod punctaffy/hypersnippet/snippet private/hypernest)

--- a/punctaffy-lib/hypersnippet/hypernest.rkt
+++ b/punctaffy-lib/hypersnippet/hypernest.rkt
@@ -20,28 +20,25 @@
 ;   language governing permissions and limitations under the License.
 
 
-; TODO NOW: Remove uses of `lathe-morphisms/private/shim`,
-; particularly including `shim-contract-out` and
-; `shim-recontract-out`.
-(require lathe-morphisms/private/shim)
+(require #/only-in racket/contract/base recontract-out)
 
 (require #/submod punctaffy/hypersnippet/snippet private/hypernest)
 
 
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest?
   hypernest/c
   hypernestof/ob-c
   hypernest-get-dim-sys)
 (provide
   hypernest-snippet-sys)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest-snippet-sys?
   hypernest-snippet-sys-snippet-format-sys
   hypernest-snippet-sys-dim-sys)
 (provide
   hypernest-snippet-format-sys)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest-snippet-format-sys?
   hypernest-snippet-format-sys-original
   hypernest-shape
@@ -50,11 +47,11 @@
 
 (provide
   hypernest-coil-zero)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest-coil-zero?)
 (provide
   hypernest-coil-hole)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest-coil-hole?
   hypernest-coil-hole-overall-degree
   hypernest-coil-hole-hole
@@ -62,37 +59,37 @@
   hypernest-coil-hole-tails-hypertee)
 (provide
   hypernest-coil-bump)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest-coil-bump?
   hypernest-coil-bump-overall-degree
   hypernest-coil-bump-data
   hypernest-coil-bump-bump-degree
   hypernest-coil-bump-tails-hypernest)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest-coil/c)
 (provide
   hypernest-furl)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest-get-coil)
 
 (provide
   hnb-open)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hnb-open?
   hnb-open-degree
   hnb-open-data)
 (provide
   hnb-labeled)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hnb-labeled?
   hnb-labeled-degree
   hnb-labeled-data)
 (provide
   hnb-unlabeled)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hnb-unlabeled?
   hnb-unlabeled-degree)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypernest-bracket?
   hypernest-bracket/c
   ; TODO: Uncomment this export if we ever need it.

--- a/punctaffy-lib/hypersnippet/hyperparameter.rkt
+++ b/punctaffy-lib/hypersnippet/hyperparameter.rkt
@@ -5,7 +5,7 @@
 ; Utilities for Racket parameters that allow the dynamic extents to be
 ; hypersnippet-shaped sections of the execution timeline.
 
-;   Copyright 2018 The Lathe Authors
+;   Copyright 2018, 2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -22,13 +22,16 @@
 
 (require #/only-in racket/contract/base
   -> any any/c contract? recursive-contract)
-(require #/only-in racket/contract/region define/contract)
 
 (require #/only-in lathe-comforts expect fn w-)
 (require #/only-in lathe-comforts/maybe just nothing)
 
+(require punctaffy/private/shim)
+(init-shim)
+
+
 ; TODO: Document all of these exports.
-(provide
+(provide #/own-contract-out
   hyperbody/c
   call-hyperbody-while-updating-parameterization
   call-hyperbody-while-parameterizing)
@@ -46,7 +49,7 @@
 ; uninstallation and reinstallation.
 
 
-(define/contract hyperbody/c
+(define/own-contract hyperbody/c
   contract?
   ; NOTE: While this is equivalent to having only one `(-> ... any)`
   ; layer instead of two, we keep them both around because they
@@ -59,7 +62,7 @@
   ; dimension instead of taking it as a parameter.
   (-> (-> (recursive-contract hyperbody/c) any) any))
 
-(define/contract
+(define/own-contract
   (call-hyperbody-while-updating-parameterization func body)
   (-> (-> parameterization? parameterization?) hyperbody/c any)
   (w- current-p (current-parameterization)
@@ -76,7 +79,7 @@
         #/call-hyperbody-while-updating-parameterization (fn _ old-p)
           body)))))
 
-(define/contract
+(define/own-contract
   (call-hyperbody-while-parameterizing pr value body)
   (-> parameter? any/c hyperbody/c any)
   (call-hyperbody-while-updating-parameterization (fn pn pn) #/fn esc

--- a/punctaffy-lib/hypersnippet/hypertee.rkt
+++ b/punctaffy-lib/hypersnippet/hypertee.rkt
@@ -20,58 +20,55 @@
 ;   language governing permissions and limitations under the License.
 
 
-; TODO NOW: Remove uses of `lathe-morphisms/private/shim`,
-; particularly including `shim-contract-out` and
-; `shim-recontract-out`.
-(require lathe-morphisms/private/shim)
+(require #/only-in racket/contract/base recontract-out)
 
 (require #/submod punctaffy/hypersnippet/snippet private/hypertee)
 
 
 (provide
   hypertee-coil-zero)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypertee-coil-zero?)
 (provide
   hypertee-coil-hole)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypertee-coil-hole?
   hypertee-coil-hole-overall-degree
   hypertee-coil-hole-hole
   hypertee-coil-hole-data
   hypertee-coil-hole-tails)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypertee-coil/c)
 (provide
   hypertee-furl)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypertee?
   hypertee-get-dim-sys
   hypertee-get-coil
   hypertee/c)
 (provide
   hypertee-snippet-sys)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypertee-snippet-sys?
   hypertee-snippet-sys-dim-sys)
 (provide
   hypertee-snippet-format-sys)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypertee-snippet-format-sys?
   hypertee-get-hole-zero-maybe)
 
 (provide
   htb-labeled)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   htb-labeled?
   htb-labeled-degree
   htb-labeled-data)
 (provide
   htb-unlabeled)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   htb-unlabeled?
   htb-unlabeled-degree)
-(provide #/shim-recontract-out
+(provide #/recontract-out
   hypertee-bracket?
   hypertee-bracket/c
   ; TODO: Uncomment this export if we ever need it.

--- a/punctaffy-lib/hypersnippet/hypertee.rkt
+++ b/punctaffy-lib/hypersnippet/hypertee.rkt
@@ -5,7 +5,7 @@
 ; A data structure for encoding the kind of higher-order structure
 ; that occurs in higher quasiquotation.
 
-;   Copyright 2017-2021 The Lathe Authors
+;   Copyright 2017-2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@
 ;   language governing permissions and limitations under the License.
 
 
+; TODO NOW: Remove uses of `lathe-morphisms/private/shim`,
+; particularly including `shim-contract-out` and
+; `shim-recontract-out`.
 (require lathe-morphisms/private/shim)
 
 (require #/submod punctaffy/hypersnippet/snippet private/hypertee)

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -5077,7 +5077,9 @@
     #:rest
     [brackets (ds)
       (w- dim/c (dim-sys-dim/c ds)
-      #/listof #/or/c (hypertee-bracket/c dim/c) dim/c)]
+      #/listof #/or/c
+        (hypertee-bracket/c dim/c)
+        (and/c (not/c hypertee-bracket?) dim/c))]
     [_ (ds) (hypertee/c ds)])
   (explicit-hypertee-from-brackets 'ht-bracs ds degree
     (list-map brackets #/fn closing-bracket

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -571,6 +571,8 @@
           (snippet-sys-shape-snippet-sys ss)
           shape))]))
 (ascribe-own-contract snippet-sys-snippet->maybe-shape
+  ; TODO SPECIFIC: See if the result contract should be more specific.
+  ; The result should always be of the same degree as the input.
   (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
     [_ (ss snippet)
       (maybe/c
@@ -4315,6 +4317,8 @@
   attenuated-hypernest-snippet-format-sys)
 
 (define/own-contract (hypernest-shape ss hn)
+  ; TODO SPECIFIC: See if the result contract should be more specific.
+  ; The result should always be of the same degree as the input.
   (->i
     ([ss hypernest-snippet-sys?] [hn (ss) (snippet-sys-snippet/c ss)])
     [_ (ss)

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -5037,7 +5037,9 @@
     #:rest
     [brackets (ds)
       (w- dim/c (dim-sys-dim/c ds)
-      #/listof #/or/c (hypernest-bracket/c dim/c) dim/c)]
+      #/listof #/or/c
+        (hypernest-bracket/c dim/c)
+        (and/c (not/c hypernest-bracket?) dim/c))]
     [_ (ds) (hypernest/c (hypertee-snippet-format-sys) ds)])
   (4:dlog 'hqq-d1
   #/explicit-hypernest-from-brackets 'hn-bracs (fn hnb hnb) ds degree

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -3060,10 +3060,7 @@
 (define attenuated-hypertee-furl
   (let ()
     (define/contract (hypertee-furl dim-sys coil)
-      (->i
-        (
-          [ds dim-sys?]
-          [coil (ds) (hypertee-coil/c ds)])
+      (->i ([ds dim-sys?] [coil (ds) (hypertee-coil/c ds)])
         [_ (ds) (hypertee/c ds)])
       (unguarded-hypertee-furl-orig dim-sys coil))
     hypertee-furl))
@@ -4553,14 +4550,11 @@
     `(hypernest-coil/c ,(value-name-for-contract ds))))
 
 ; NOTE DEBUGGABILITY: This is a `define/own-contract` for debugging.
-(define/own-contract (unguarded-fn-hypernest-furl dim-sys coil)
-  (->i
-    (
-      [dim-sys dim-sys?]
-      [coil (dim-sys) (hypernest-coil/c dim-sys)])
+(define/own-contract (unguarded-fn-hypernest-furl ds coil)
+  (->i ([ds dim-sys?] [coil (ds) (hypernest-coil/c ds)])
     [_ hypernest?])
   (dlog 'l1
-  #/w- uds dim-sys
+  #/w- uds ds
   #/w- eds (extended-with-top-dim-sys #/extended-with-top-dim-sys uds)
   #/w- ehtss (hypertee-snippet-sys eds)
   #/w- extend-dim
@@ -4772,13 +4766,10 @@
 ; function-like side and not actually the match expander.
 (define attenuated-fn-hypernest-furl
   (let ()
-    (define/contract (hypernest-furl dim-sys coil)
-      (->i
-        (
-          [dim-sys dim-sys?]
-          [coil (dim-sys) (hypernest-coil/c dim-sys)])
+    (define/contract (hypernest-furl ds coil)
+      (->i ([ds dim-sys?] [coil (ds) (hypernest-coil/c ds)])
         [_ hypernest?])
-      (unguarded-hypernest-furl dim-sys coil))
+      (unguarded-hypernest-furl ds coil))
     hypernest-furl))
 #;
 (define-match-expander-attenuated

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -166,6 +166,12 @@
 (require lathe-morphisms/private/shim)
 (require punctaffy/private/shim)
 (init-shim)
+(module+ private/hypertee
+  (require punctaffy/private/shim)
+  (init-shim))
+(module+ private/hypernest
+  (require punctaffy/private/shim)
+  (init-shim))
 
 (require #/only-in punctaffy/hypersnippet/dim
   dim-sys? dim-sys-category-sys dim-sys-category-sys? dim-sys-dim<?
@@ -337,79 +343,55 @@
 
 (module+ private/hypertee #/provide
   hypertee-coil-zero)
-(module+ private/hypertee #/provide #/shim-contract-out
-  [hypertee-coil-zero? (-> any/c boolean?)])
+(module+ private/hypertee #/provide #/own-contract-out
+  hypertee-coil-zero?)
 (module+ private/hypertee #/provide
   hypertee-coil-hole)
-(module+ private/hypertee #/provide #/shim-contract-out
-  [hypertee-coil-hole? (-> any/c boolean?)]
-  [hypertee-coil-hole-overall-degree (-> hypertee-coil-hole? any/c)]
-  [hypertee-coil-hole-hole (-> hypertee-coil-hole? any/c)]
-  [hypertee-coil-hole-data (-> hypertee-coil-hole? any/c)]
-  [hypertee-coil-hole-tails (-> hypertee-coil-hole? any/c)])
-(module+ private/hypertee #/provide #/shim-contract-out
-  [hypertee-coil/c (-> dim-sys? flat-contract?)])
+(module+ private/hypertee #/provide #/own-contract-out
+  hypertee-coil-hole?
+  hypertee-coil-hole-overall-degree
+  hypertee-coil-hole-hole
+  hypertee-coil-hole-data
+  hypertee-coil-hole-tails)
+(module+ private/hypertee #/provide #/own-contract-out
+  hypertee-coil/c)
 (module+ private/hypertee #/provide
   hypertee-furl)
-(module+ private/hypertee #/provide #/shim-contract-out
-  [hypertee? (-> any/c boolean?)]
-  [hypertee-get-dim-sys (-> hypertee? dim-sys?)]
-  [hypertee-get-coil
-    (->i ([ht hypertee?])
-      [_ (ht) (hypertee-coil/c #/hypertee-get-dim-sys ht)])]
-  [hypertee/c (-> dim-sys? flat-contract?)])
+(module+ private/hypertee #/provide #/own-contract-out
+  hypertee?
+  hypertee-get-dim-sys
+  hypertee-get-coil
+  hypertee/c)
 (module+ private/hypertee #/provide
   hypertee-snippet-sys)
-(module+ private/hypertee #/provide #/shim-contract-out
-  [hypertee-snippet-sys? (-> any/c boolean?)]
-  [hypertee-snippet-sys-dim-sys (-> hypertee-snippet-sys? dim-sys?)])
+(module+ private/hypertee #/provide #/own-contract-out
+  hypertee-snippet-sys?
+  hypertee-snippet-sys-dim-sys)
 (module+ private/hypertee #/provide
   hypertee-snippet-format-sys)
-(module+ private/hypertee #/provide #/shim-contract-out
-  [hypertee-snippet-format-sys? (-> any/c boolean?)]
-  [hypertee-get-hole-zero-maybe
-    (->
-      (and/c hypertee?
-        (by-own-method/c #:obstinacy (flat-obstinacy) ht
-          (hypertee/c #/hypertee-get-dim-sys ht)))
-      maybe?)])
+(module+ private/hypertee #/provide #/own-contract-out
+  hypertee-snippet-format-sys?
+  hypertee-get-hole-zero-maybe)
 
 (module+ private/hypertee #/provide
   htb-labeled)
-(module+ private/hypertee #/provide #/shim-contract-out
-  [htb-labeled? (-> any/c boolean?)]
-  [htb-labeled-degree (-> htb-labeled? any/c)]
-  [htb-labeled-data (-> htb-labeled? any/c)])
+(module+ private/hypertee #/provide #/own-contract-out
+  htb-labeled?
+  htb-labeled-degree
+  htb-labeled-data)
 (module+ private/hypertee #/provide
   htb-unlabeled)
-(module+ private/hypertee #/provide #/shim-contract-out
-  [htb-unlabeled? (-> any/c boolean?)]
-  [htb-unlabeled-degree (-> htb-unlabeled? any/c)])
-(module+ private/hypertee #/provide #/shim-contract-out
-  [hypertee-bracket? (-> any/c boolean?)]
-  [hypertee-bracket/c (-> contract? contract?)]
+(module+ private/hypertee #/provide #/own-contract-out
+  htb-unlabeled?
+  htb-unlabeled-degree)
+(module+ private/hypertee #/provide #/own-contract-out
+  hypertee-bracket?
+  hypertee-bracket/c
   ; TODO: Uncomment this export if we ever need it.
-;  [hypertee-bracket-degree (-> hypertee-bracket? any/c)]
-  [hypertee-from-brackets
-    (->i
-      (
-        [ds dim-sys?]
-        [degree (ds) (dim-sys-dim/c ds)]
-        [brackets (ds)
-          (listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])
-      [_ (ds) (hypertee/c ds)])]
-  [ht-bracs
-    (->i ([ds dim-sys?] [degree (ds) (dim-sys-dim/c ds)])
-      #:rest
-      [brackets (ds)
-        (w- dim/c (dim-sys-dim/c ds)
-        #/listof #/or/c (hypertee-bracket/c dim/c) dim/c)]
-      [_ (ds) (hypertee/c ds)])]
-  [hypertee-get-brackets
-    (->i ([ht hypertee?])
-      [_ (ht)
-        (w- ds (hypertee-get-dim-sys ht)
-        #/listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])])
+;  hypertee-bracket-degree
+  hypertee-from-brackets
+  ht-bracs
+  hypertee-get-brackets)
 
 (module+ private/hypernest #/provide #/shim-contract-out
   [hypernest? (-> any/c boolean?)]
@@ -3030,6 +3012,7 @@
   (hypertee-coil-zero?)
   hypertee-coil-zero
   'hypertee-coil-zero (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypertee-coil-zero? (-> any/c boolean?))
 (define-imitation-simple-struct
   (hypertee-coil-hole?
     hypertee-coil-hole-overall-degree
@@ -3038,6 +3021,15 @@
     hypertee-coil-hole-tails)
   hypertee-coil-hole
   'hypertee-coil-hole (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypertee-coil-hole? (-> any/c boolean?))
+(ascribe-own-contract hypertee-coil-hole-overall-degree
+  (-> hypertee-coil-hole? any/c))
+(ascribe-own-contract hypertee-coil-hole-hole
+  (-> hypertee-coil-hole? any/c))
+(ascribe-own-contract hypertee-coil-hole-data
+  (-> hypertee-coil-hole? any/c))
+(ascribe-own-contract hypertee-coil-hole-tails
+  (-> hypertee-coil-hole? any/c))
 
 ; NOTE DEBUGGABILITY: This is here for debugging.
 (define/own-contract
@@ -3073,7 +3065,8 @@
             #'(hypertee-coil-hole))
           overall-degree hole data tails))))
 
-(define (hypertee-coil/c ds)
+(define/own-contract (hypertee-coil/c ds)
+  (-> dim-sys? flat-contract?)
   (w- ss (hypertee-snippet-sys ds)
   #/rename-contract
     (or/c
@@ -3129,6 +3122,11 @@
                 (if (hypertee-bracket? d)
                   (htb-unlabeled d)
                   d)))))))))
+(ascribe-own-contract hypertee? (-> any/c boolean?))
+(ascribe-own-contract hypertee-get-dim-sys (-> hypertee? dim-sys?))
+(ascribe-own-contract hypertee-get-coil
+  (->i ([ht hypertee?])
+    [_ (ht) (hypertee-coil/c #/hypertee-get-dim-sys ht)]))
 ; TODO: We have a dilemma. The `define/contract` version of
 ; `attenuated-hypertee-furl` will give less precise source location
 ; information in its errors, and it won't catch applications with
@@ -3178,7 +3176,8 @@
     unguarded-hypertee-furl-orig))
 
 ; TODO: Use the things that use this.
-(define (hypertee/c ds)
+(define/own-contract (hypertee/c ds)
+  (-> dim-sys? flat-contract?)
   (rename-contract (match/c unguarded-hypertee-furl (ok/c ds) any/c)
     `(hypertee/c ,(value-name-for-contract ds))))
 
@@ -3570,6 +3569,9 @@
       #/fn hole data
         (dissect data (list i data)
         #/hash-ref env i)))))
+(ascribe-own-contract hypertee-snippet-sys? (-> any/c boolean?))
+(ascribe-own-contract hypertee-snippet-sys-dim-sys
+  (-> hypertee-snippet-sys? dim-sys?))
 (define-match-expander-attenuated
   attenuated-hypertee-snippet-sys
   unguarded-hypertee-snippet-sys
@@ -3679,8 +3681,15 @@
       ; snippet-format-sys-functor
       (dissectfn _
         (hypertee-functor-from-dim-sys-to-snippet-sys-sys)))))
+(ascribe-own-contract hypertee-snippet-format-sys?
+  (-> any/c boolean?))
 
-(define (hypertee-get-hole-zero-maybe ht)
+(define/own-contract (hypertee-get-hole-zero-maybe ht)
+  (->
+    (and/c hypertee?
+      (by-own-method/c #:obstinacy (flat-obstinacy) ht
+        (hypertee/c #/hypertee-get-dim-sys ht)))
+    maybe?)
   (4:dlog 'hqq-j4
   #/dissect ht (unguarded-hypertee-furl ds coil)
   #/w- ss (hypertee-snippet-sys ds)
@@ -4789,17 +4798,24 @@
   (htb-labeled? htb-labeled-degree htb-labeled-data)
   htb-labeled
   'htb-labeled (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract htb-labeled? (-> any/c boolean?))
+(ascribe-own-contract htb-labeled-degree (-> htb-labeled? any/c))
+(ascribe-own-contract htb-labeled-data (-> htb-labeled? any/c))
 (define-imitation-simple-struct
   (htb-unlabeled? htb-unlabeled-degree)
   htb-unlabeled
   'htb-unlabeled (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract htb-unlabeled? (-> any/c boolean?))
+(ascribe-own-contract htb-unlabeled-degree (-> htb-unlabeled? any/c))
 
 ; TODO: Use this.
-(define (hypertee-bracket? v)
+(define/own-contract (hypertee-bracket? v)
+  (-> any/c boolean?)
   (or (htb-labeled? v) (htb-unlabeled? v)))
 
 ; TODO: Use this.
-(define (hypertee-bracket/c dim/c)
+(define/own-contract (hypertee-bracket/c dim/c)
+  (-> contract? contract?)
   (w- dim/c (coerce-contract 'hypertee-bracket/c dim/c)
   #/rename-contract
     (or/c
@@ -4808,7 +4824,8 @@
     `(hypertee-bracket/c ,(contract-name dim/c))))
 
 ; TODO: Use this.
-(define (hypertee-bracket-degree bracket)
+(define/own-contract (hypertee-bracket-degree bracket)
+  (-> hypertee-bracket? any/c)
   (mat bracket (htb-labeled d data) d
   #/dissect bracket (htb-unlabeled d) d))
 
@@ -5020,12 +5037,25 @@
           (hypertee-bracket->hypernest-bracket htb))))))
 
 ; TODO: Use this.
-(define (hypertee-from-brackets ds degree brackets)
+(define/own-contract (hypertee-from-brackets ds degree brackets)
+  (->i
+    (
+      [ds dim-sys?]
+      [degree (ds) (dim-sys-dim/c ds)]
+      [brackets (ds)
+        (listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])
+    [_ (ds) (hypertee/c ds)])
   (explicit-hypertee-from-brackets
     'hypertee-from-brackets ds degree brackets))
 
 ; TODO: Use this.
-(define (ht-bracs ds degree . brackets)
+(define/own-contract (ht-bracs ds degree . brackets)
+  (->i ([ds dim-sys?] [degree (ds) (dim-sys-dim/c ds)])
+    #:rest
+    [brackets (ds)
+      (w- dim/c (dim-sys-dim/c ds)
+      #/listof #/or/c (hypertee-bracket/c dim/c) dim/c)]
+    [_ (ds) (hypertee/c ds)])
   (explicit-hypertee-from-brackets 'ht-bracs ds degree
     (list-map brackets #/fn closing-bracket
       (if (hypertee-bracket? closing-bracket)
@@ -5098,7 +5128,11 @@
 
 ; TODO: Export this.
 ; TODO: Use this.
-(define (hypertee-get-brackets ht)
+(define/own-contract (hypertee-get-brackets ht)
+  (->i ([ht hypertee?])
+    [_ (ht)
+      (w- ds (hypertee-get-dim-sys ht)
+      #/listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])
   (dissect ht (unguarded-hypertee-furl ds coil)
   #/list-map
     (hypernest-get-brackets #/snippet-sys-shape->snippet

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -266,131 +266,34 @@
   prop:snippet-sys
   ; TODO: See if we can come up with a better name or interface for
   ; this.
-  make-snippet-sys-impl-from-various-1)
-(provide #/shim-contract-out
+  make-snippet-sys-impl-from-various-1
   
-  [snippet-sys-morphism-sys? (-> any/c boolean?)]
-  [snippet-sys-morphism-sys-impl? (-> any/c boolean?)]
-  [snippet-sys-morphism-sys-source
-    (-> snippet-sys-morphism-sys? snippet-sys?)]
-  [snippet-sys-morphism-sys-replace-source
-    (-> snippet-sys-morphism-sys? snippet-sys?
-      snippet-sys-morphism-sys?)]
-  [snippet-sys-morphism-sys-target
-    (-> snippet-sys-morphism-sys? snippet-sys?)]
-  [snippet-sys-morphism-sys-replace-target
-    (-> snippet-sys-morphism-sys? snippet-sys?
-      snippet-sys-morphism-sys?)]
-  [snippet-sys-morphism-sys-dim-sys-morphism-sys
-    (-> snippet-sys-morphism-sys? dim-sys-morphism-sys?)]
-  [snippet-sys-morphism-sys-shape-snippet-sys-morphism-sys
-    (-> snippet-sys-morphism-sys? snippet-sys-morphism-sys?)]
-  [snippet-sys-morphism-sys-morph-snippet
-    (->i
-      (
-        [ms snippet-sys-morphism-sys?]
-        [s (ms)
-          (snippet-sys-snippet/c
-            (snippet-sys-morphism-sys-source ms))])
-      [_ (ms)
-        (snippet-sys-snippet/c
-          (snippet-sys-morphism-sys-target ms))])]
-  [snippet-sys-morphism-sys/c (-> contract? contract? contract?)]
-  [prop:snippet-sys-morphism-sys
-    (struct-type-property/c snippet-sys-morphism-sys-impl?)]
-  [make-snippet-sys-morphism-sys-impl-from-morph
-    (->
-      (-> snippet-sys-morphism-sys? snippet-sys?)
-      (-> snippet-sys-morphism-sys? snippet-sys?
-        snippet-sys-morphism-sys?)
-      (-> snippet-sys-morphism-sys? snippet-sys?)
-      (-> snippet-sys-morphism-sys? snippet-sys?
-        snippet-sys-morphism-sys?)
-      (-> snippet-sys-morphism-sys? dim-sys-morphism-sys?)
-      (-> snippet-sys-morphism-sys? snippet-sys-morphism-sys?)
-      (->i
-        (
-          [ms snippet-sys-morphism-sys?]
-          [s (ms)
-            (snippet-sys-snippet/c
-              (snippet-sys-morphism-sys-source ms))])
-        [_ (ms)
-          (snippet-sys-snippet/c
-            (snippet-sys-morphism-sys-target ms))])
-      snippet-sys-morphism-sys-impl?)]
-  [snippet-sys-morphism-sys-identity
-    (->i ([endpoint snippet-sys?])
-      [_ (endpoint)
-        (snippet-sys-morphism-sys/c
-          (ok/c endpoint)
-          (ok/c endpoint))])]
-  [snippet-sys-morphism-sys-chain-two
-    (->i
-      (
-        [a snippet-sys-morphism-sys?]
-        [b (a)
-          (snippet-sys-morphism-sys/c
-            (ok/c #/snippet-sys-morphism-sys-target a)
-            any/c)])
-      [_ (a b)
-        (snippet-sys-morphism-sys/c
-          (ok/c #/snippet-sys-morphism-sys-source a)
-          (ok/c #/snippet-sys-morphism-sys-target b))])])
+  snippet-sys-morphism-sys?
+  snippet-sys-morphism-sys-impl?
+  snippet-sys-morphism-sys-source
+  snippet-sys-morphism-sys-replace-source
+  snippet-sys-morphism-sys-target
+  snippet-sys-morphism-sys-replace-target
+  snippet-sys-morphism-sys-dim-sys-morphism-sys
+  snippet-sys-morphism-sys-shape-snippet-sys-morphism-sys
+  snippet-sys-morphism-sys-morph-snippet
+  snippet-sys-morphism-sys/c
+  prop:snippet-sys-morphism-sys
+  make-snippet-sys-morphism-sys-impl-from-morph
+  snippet-sys-morphism-sys-identity
+  snippet-sys-morphism-sys-chain-two)
 
 (provide
   snippet-sys-category-sys)
-(provide #/shim-contract-out
-  [snippet-sys-category-sys? (-> any/c boolean?)])
+(provide #/own-contract-out
+  snippet-sys-category-sys?)
 
-(provide #/shim-contract-out
-  [functor-from-dim-sys-to-snippet-sys-sys? (-> any/c boolean?)]
-  [make-functor-from-dim-sys-to-snippet-sys-sys-impl-from-apply
-    (->
-      (-> functor-from-dim-sys-to-snippet-sys-sys? dim-sys?
-        snippet-sys?)
-      (->i
-        (
-          [fs functor-from-dim-sys-to-snippet-sys-sys?]
-          [ms dim-sys-morphism-sys?])
-        [_ (fs ms)
-          (snippet-sys-morphism-sys/c
-            (ok/c
-              (functor-sys-apply-to-object fs
-                (dim-sys-morphism-sys-source ms)))
-            (ok/c
-              (functor-sys-apply-to-object fs
-                (dim-sys-morphism-sys-target ms))))])
-      functor-sys-impl?)]
+(provide #/own-contract-out
+  functor-from-dim-sys-to-snippet-sys-sys?
+  make-functor-from-dim-sys-to-snippet-sys-sys-impl-from-apply
   
-  [functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
-    (-> any/c boolean?)]
-  [make-functor-from-dim-sys-to-snippet-sys-sys-morphism-sys-impl-from-apply
-    (->
-      (-> functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
-        functor-from-dim-sys-to-snippet-sys-sys?)
-      (->
-        functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
-        functor-from-dim-sys-to-snippet-sys-sys?
-        functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?)
-      (-> functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
-        functor-from-dim-sys-to-snippet-sys-sys?)
-      (->
-        functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
-        functor-from-dim-sys-to-snippet-sys-sys?
-        functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?)
-      (->i
-        (
-          [ms functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?]
-          [dsms dim-sys-morphism-sys?])
-        [_ (ms dsms)
-          (snippet-sys-morphism-sys/c
-            (functor-sys-apply-to-object
-              (natural-transformation-sys-source ms)
-              (dim-sys-morphism-sys-source dsms))
-            (functor-sys-apply-to-object
-              (natural-transformation-sys-target ms)
-              (dim-sys-morphism-sys-target dsms)))])
-      natural-transformation-sys-impl?)]
+  functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
+  make-functor-from-dim-sys-to-snippet-sys-sys-morphism-sys-impl-from-apply
   
   ; A `snippet-format-sys?` is a wrapped functor from the `dim-sys?`
   ; category to the `snippet-sys?` category that guarantees the
@@ -404,91 +307,33 @@
   ; We've already mentioned this in the docs, but we mention it again
   ; here as a reminder.
   ;
-  [snippet-format-sys? (-> any/c boolean?)]
-  [snippet-format-sys-impl? (-> any/c boolean?)]
-  [snippet-format-sys-functor
-    (-> snippet-format-sys? functor-from-dim-sys-to-snippet-sys-sys?)]
-  [prop:snippet-format-sys
-    (struct-type-property/c snippet-format-sys-impl?)]
-  [make-snippet-format-sys-impl-from-functor
-    (->
-      (-> snippet-format-sys?
-        functor-from-dim-sys-to-snippet-sys-sys?)
-      snippet-format-sys-impl?)]
+  snippet-format-sys?
+  snippet-format-sys-impl?
+  snippet-format-sys-functor
+  prop:snippet-format-sys
+  make-snippet-format-sys-impl-from-functor
   
-  [snippet-format-sys-morphism-sys? (-> any/c boolean?)]
-  [snippet-format-sys-morphism-sys-impl? (-> any/c boolean?)]
-  [snippet-format-sys-morphism-sys-source
-    (-> snippet-format-sys-morphism-sys? snippet-format-sys?)]
-  [snippet-format-sys-morphism-sys-replace-source
-    (-> snippet-format-sys-morphism-sys? snippet-format-sys?
-      snippet-format-sys-morphism-sys?)]
-  [snippet-format-sys-morphism-sys-target
-    (-> snippet-format-sys-morphism-sys? snippet-format-sys?)]
-  [snippet-format-sys-morphism-sys-replace-target
-    (-> snippet-format-sys-morphism-sys? snippet-format-sys?
-      snippet-format-sys-morphism-sys?)]
-  [snippet-format-sys-morphism-sys-functor-morphism
-    (-> snippet-format-sys-morphism-sys?
-      functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?)]
-  [snippet-format-sys-morphism-sys/c
-    (-> contract? contract? contract?)]
-  [prop:snippet-format-sys-morphism-sys
-    (struct-type-property/c snippet-format-sys-morphism-sys-impl?)]
-  [make-snippet-format-sys-morphism-sys-impl-from-morph
-    (->
-      (-> snippet-format-sys-morphism-sys? snippet-format-sys?)
-      (-> snippet-format-sys-morphism-sys? snippet-format-sys?
-        snippet-format-sys-morphism-sys?)
-      (-> snippet-format-sys-morphism-sys? snippet-format-sys?)
-      (-> snippet-format-sys-morphism-sys? snippet-format-sys?
-        snippet-format-sys-morphism-sys?)
-      (-> snippet-format-sys-morphism-sys?
-        functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?)
-      snippet-format-sys-morphism-sys-impl?)]
-  [snippet-format-sys-morphism-sys-identity
-    (->i ([endpoint snippet-format-sys?])
-      [_ (endpoint)
-        (snippet-format-sys-morphism-sys/c
-          (ok/c endpoint)
-          (ok/c endpoint))])]
-  [snippet-format-sys-morphism-sys-chain-two
-    (->i
-      (
-        [a snippet-format-sys-morphism-sys?]
-        [b (a)
-          (snippet-format-sys-morphism-sys/c
-            (ok/c #/snippet-format-sys-morphism-sys-target a)
-            any/c)])
-      [_ (a b)
-        (snippet-format-sys-morphism-sys/c
-          (ok/c #/snippet-format-sys-morphism-sys-source a)
-          (ok/c #/snippet-format-sys-morphism-sys-target b))])])
+  snippet-format-sys-morphism-sys?
+  snippet-format-sys-morphism-sys-impl?
+  snippet-format-sys-morphism-sys-source
+  snippet-format-sys-morphism-sys-replace-source
+  snippet-format-sys-morphism-sys-target
+  snippet-format-sys-morphism-sys-replace-target
+  snippet-format-sys-morphism-sys-functor-morphism
+  snippet-format-sys-morphism-sys/c
+  prop:snippet-format-sys-morphism-sys
+  make-snippet-format-sys-morphism-sys-impl-from-morph
+  snippet-format-sys-morphism-sys-identity
+  snippet-format-sys-morphism-sys-chain-two)
 
 (provide
   snippet-format-sys-category-sys)
-(provide #/shim-contract-out
-  [snippet-format-sys-category-sys? (-> any/c boolean?)])
+(provide #/own-contract-out
+  snippet-format-sys-category-sys?)
 
-(provide #/shim-contract-out
-  [snippet-format-sys-endofunctor-sys? (-> any/c boolean?)]
-  [make-snippet-format-sys-endofunctor-sys-impl-from-apply
-    (->
-      (-> snippet-format-sys-endofunctor-sys? snippet-format-sys?
-        snippet-format-sys?)
-      (->i
-        (
-          [es snippet-format-sys-endofunctor-sys?]
-          [ms snippet-format-sys-morphism-sys?])
-        [_ (es ms)
-          (snippet-format-sys-morphism-sys/c
-            (ok/c
-              (functor-sys-apply-to-object es
-                (snippet-format-sys-morphism-sys-source ms)))
-            (ok/c
-              (functor-sys-apply-to-object es
-                (snippet-format-sys-morphism-sys-target ms))))])
-      functor-sys-impl?)])
+(provide #/own-contract-out
+  snippet-format-sys-endofunctor-sys?
+  make-snippet-format-sys-endofunctor-sys-impl-from-apply)
 
 (module+ private/hypertee #/provide
   hypertee-coil-zero)
@@ -1660,8 +1505,54 @@
   prop:snippet-sys-morphism-sys
   make-snippet-sys-morphism-sys-impl-from-morph
   'snippet-sys-morphism-sys 'snippet-sys-morphism-sys-impl (list))
+(ascribe-own-contract snippet-sys-morphism-sys? (-> any/c boolean?))
+(ascribe-own-contract snippet-sys-morphism-sys-impl? (-> any/c boolean?))
+(ascribe-own-contract snippet-sys-morphism-sys-source
+  (-> snippet-sys-morphism-sys? snippet-sys?))
+(ascribe-own-contract snippet-sys-morphism-sys-replace-source
+  (-> snippet-sys-morphism-sys? snippet-sys?
+    snippet-sys-morphism-sys?))
+(ascribe-own-contract snippet-sys-morphism-sys-target
+  (-> snippet-sys-morphism-sys? snippet-sys?))
+(ascribe-own-contract snippet-sys-morphism-sys-replace-target
+  (-> snippet-sys-morphism-sys? snippet-sys?
+    snippet-sys-morphism-sys?))
+(ascribe-own-contract snippet-sys-morphism-sys-dim-sys-morphism-sys
+  (-> snippet-sys-morphism-sys? dim-sys-morphism-sys?))
+(ascribe-own-contract snippet-sys-morphism-sys-shape-snippet-sys-morphism-sys
+  (-> snippet-sys-morphism-sys? snippet-sys-morphism-sys?))
+(ascribe-own-contract snippet-sys-morphism-sys-morph-snippet
+  (->i
+    (
+      [ms snippet-sys-morphism-sys?]
+      [s (ms)
+        (snippet-sys-snippet/c #/snippet-sys-morphism-sys-source ms)])
+    [_ (ms)
+      (snippet-sys-snippet/c #/snippet-sys-morphism-sys-target ms)]))
+(ascribe-own-contract prop:snippet-sys-morphism-sys
+  (struct-type-property/c snippet-sys-morphism-sys-impl?))
+(ascribe-own-contract make-snippet-sys-morphism-sys-impl-from-morph
+  (->
+    (-> snippet-sys-morphism-sys? snippet-sys?)
+    (-> snippet-sys-morphism-sys? snippet-sys?
+      snippet-sys-morphism-sys?)
+    (-> snippet-sys-morphism-sys? snippet-sys?)
+    (-> snippet-sys-morphism-sys? snippet-sys?
+      snippet-sys-morphism-sys?)
+    (-> snippet-sys-morphism-sys? dim-sys-morphism-sys?)
+    (-> snippet-sys-morphism-sys? snippet-sys-morphism-sys?)
+    (->i
+      (
+        [ms snippet-sys-morphism-sys?]
+        [s (ms)
+          (snippet-sys-snippet/c
+            (snippet-sys-morphism-sys-source ms))])
+      [_ (ms)
+        (snippet-sys-snippet/c #/snippet-sys-morphism-sys-target ms)])
+    snippet-sys-morphism-sys-impl?))
 
-(define (snippet-sys-morphism-sys/c source/c target/c)
+(define/own-contract (snippet-sys-morphism-sys/c source/c target/c)
+  (-> contract? contract? contract?)
   (w- source/c (coerce-contract 'snippet-sys-morphism-sys/c source/c)
   #/w- target/c (coerce-contract 'snippet-sys-morphism-sys/c target/c)
   #/w- name
@@ -1750,7 +1641,10 @@
       (fn ms s s))))
 
 ; TODO: Use this.
-(define (snippet-sys-morphism-sys-identity endpoint)
+(define/own-contract (snippet-sys-morphism-sys-identity endpoint)
+  (->i ([endpoint snippet-sys?])
+    [_ (endpoint)
+      (snippet-sys-morphism-sys/c (ok/c endpoint) (ok/c endpoint))])
   (identity-snippet-sys-morphism-sys endpoint))
 
 (define-imitation-simple-struct
@@ -1806,7 +1700,18 @@
           (snippet-sys-morphism-sys-morph-snippet a s))))))
 
 ; TODO: Use this.
-(define (snippet-sys-morphism-sys-chain-two a b)
+(define/own-contract (snippet-sys-morphism-sys-chain-two a b)
+  (->i
+    (
+      [a snippet-sys-morphism-sys?]
+      [b (a)
+        (snippet-sys-morphism-sys/c
+          (ok/c #/snippet-sys-morphism-sys-target a)
+          any/c)])
+    [_ (a b)
+      (snippet-sys-morphism-sys/c
+        (ok/c #/snippet-sys-morphism-sys-source a)
+        (ok/c #/snippet-sys-morphism-sys-target b))])
   (chain-two-snippet-sys-morphism-sys a b))
 
 
@@ -1842,18 +1747,36 @@
       ; category-sys-morphism-chain-two
       (fn cs a b c ab bc
         (snippet-sys-morphism-sys-chain-two ab bc)))))
+(ascribe-own-contract snippet-sys-category-sys? (-> any/c boolean?))
 
 
-(define (functor-from-dim-sys-to-snippet-sys-sys? v)
+(define/own-contract (functor-from-dim-sys-to-snippet-sys-sys? v)
+  (-> any/c boolean?)
   (
     (flat-contract-predicate
       (functor-sys/c dim-sys-category-sys? snippet-sys-category-sys?))
     v))
 
-(define
+(define/own-contract
   (make-functor-from-dim-sys-to-snippet-sys-sys-impl-from-apply
     apply-to-dim-sys
     apply-to-dim-sys-morphism-sys)
+  (->
+    (-> functor-from-dim-sys-to-snippet-sys-sys? dim-sys?
+      snippet-sys?)
+    (->i
+      (
+        [fs functor-from-dim-sys-to-snippet-sys-sys?]
+        [ms dim-sys-morphism-sys?])
+      [_ (fs ms)
+        (snippet-sys-morphism-sys/c
+          (ok/c
+            (functor-sys-apply-to-object fs
+              (dim-sys-morphism-sys-source ms)))
+          (ok/c
+            (functor-sys-apply-to-object fs
+              (dim-sys-morphism-sys-target ms))))])
+    functor-sys-impl?)
   (make-functor-sys-impl-from-apply
     ; functor-sys-source
     (fn fs #/dim-sys-category-sys)
@@ -1883,20 +1806,48 @@
     (fn fs a b ms #/apply-to-dim-sys-morphism-sys fs ms)))
 
 
-(define (functor-from-dim-sys-to-snippet-sys-sys-morphism-sys? v)
+(define/own-contract
+  (functor-from-dim-sys-to-snippet-sys-sys-morphism-sys? v)
+  (-> any/c boolean?)
   (
     (flat-contract-predicate
       (natural-transformation-sys/c
         dim-sys? snippet-sys? any/c any/c))
     v))
 
-(define
+(define/own-contract
   (make-functor-from-dim-sys-to-snippet-sys-sys-morphism-sys-impl-from-apply
     source
     replace-source
     target
     replace-target
     apply-to-dim-sys-morphism-sys)
+  (->
+    (-> functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
+      functor-from-dim-sys-to-snippet-sys-sys?)
+    (->
+      functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
+      functor-from-dim-sys-to-snippet-sys-sys?
+      functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?)
+    (-> functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
+      functor-from-dim-sys-to-snippet-sys-sys?)
+    (->
+      functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?
+      functor-from-dim-sys-to-snippet-sys-sys?
+      functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?)
+    (->i
+      (
+        [ms functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?]
+        [dsms dim-sys-morphism-sys?])
+      [_ (ms dsms)
+        (snippet-sys-morphism-sys/c
+          (functor-sys-apply-to-object
+            (natural-transformation-sys-source ms)
+            (dim-sys-morphism-sys-source dsms))
+          (functor-sys-apply-to-object
+            (natural-transformation-sys-target ms)
+            (dim-sys-morphism-sys-target dsms)))])
+    natural-transformation-sys-impl?)
   (make-natural-transformation-sys-impl-from-apply
     ; functor-sys-endpoint-source
     (fn nts #/dim-sys-category-sys)
@@ -1941,6 +1892,16 @@
   prop:snippet-format-sys
   make-snippet-format-sys-impl-from-functor
   'snippet-format-sys 'snippet-format-sys-impl (list))
+(ascribe-own-contract snippet-format-sys? (-> any/c boolean?))
+(ascribe-own-contract snippet-format-sys-impl? (-> any/c boolean?))
+(ascribe-own-contract snippet-format-sys-functor
+  (-> snippet-format-sys? functor-from-dim-sys-to-snippet-sys-sys?))
+(ascribe-own-contract prop:snippet-format-sys
+  (struct-type-property/c snippet-format-sys-impl?))
+(ascribe-own-contract make-snippet-format-sys-impl-from-functor
+  (->
+    (-> snippet-format-sys? functor-from-dim-sys-to-snippet-sys-sys?)
+    snippet-format-sys-impl?))
 
 
 (define-imitation-simple-generics
@@ -1960,8 +1921,41 @@
   'snippet-format-sys-morphism-sys
   'snippet-format-sys-morphism-sys-impl
   (list))
+(ascribe-own-contract snippet-format-sys-morphism-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract snippet-format-sys-morphism-sys-impl?
+  (-> any/c boolean?))
+(ascribe-own-contract snippet-format-sys-morphism-sys-source
+  (-> snippet-format-sys-morphism-sys? snippet-format-sys?))
+(ascribe-own-contract snippet-format-sys-morphism-sys-replace-source
+  (-> snippet-format-sys-morphism-sys? snippet-format-sys?
+    snippet-format-sys-morphism-sys?))
+(ascribe-own-contract snippet-format-sys-morphism-sys-target
+  (-> snippet-format-sys-morphism-sys? snippet-format-sys?))
+(ascribe-own-contract snippet-format-sys-morphism-sys-replace-target
+  (-> snippet-format-sys-morphism-sys? snippet-format-sys?
+    snippet-format-sys-morphism-sys?))
+(ascribe-own-contract snippet-format-sys-morphism-sys-functor-morphism
+  (-> snippet-format-sys-morphism-sys?
+    functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?))
+(ascribe-own-contract prop:snippet-format-sys-morphism-sys
+  (struct-type-property/c snippet-format-sys-morphism-sys-impl?))
+(ascribe-own-contract
+  make-snippet-format-sys-morphism-sys-impl-from-morph
+  (->
+    (-> snippet-format-sys-morphism-sys? snippet-format-sys?)
+    (-> snippet-format-sys-morphism-sys? snippet-format-sys?
+      snippet-format-sys-morphism-sys?)
+    (-> snippet-format-sys-morphism-sys? snippet-format-sys?)
+    (-> snippet-format-sys-morphism-sys? snippet-format-sys?
+      snippet-format-sys-morphism-sys?)
+    (-> snippet-format-sys-morphism-sys?
+      functor-from-dim-sys-to-snippet-sys-sys-morphism-sys?)
+    snippet-format-sys-morphism-sys-impl?))
 
-(define (snippet-format-sys-morphism-sys/c source/c target/c)
+(define/own-contract
+  (snippet-format-sys-morphism-sys/c source/c target/c)
+  (-> contract? contract? contract?)
   (w- source/c
     (coerce-contract 'snippet-format-sys-morphism-sys/c source/c)
   #/w- target/c
@@ -2047,7 +2041,13 @@
           (snippet-format-sys-functor e))))))
 
 ; TODO: Use this.
-(define (snippet-format-sys-morphism-sys-identity endpoint)
+(define/own-contract
+  (snippet-format-sys-morphism-sys-identity endpoint)
+  (->i ([endpoint snippet-format-sys?])
+    [_ (endpoint)
+      (snippet-format-sys-morphism-sys/c
+        (ok/c endpoint)
+        (ok/c endpoint))])
   (identity-snippet-format-sys-morphism-sys endpoint))
 
 (define-imitation-simple-struct
@@ -2092,7 +2092,18 @@
           (snippet-format-sys-morphism-sys-functor-morphism b))))))
 
 ; TODO: Use this.
-(define (snippet-format-sys-morphism-sys-chain-two a b)
+(define/own-contract (snippet-format-sys-morphism-sys-chain-two a b)
+  (->i
+    (
+      [a snippet-format-sys-morphism-sys?]
+      [b (a)
+        (snippet-format-sys-morphism-sys/c
+          (ok/c #/snippet-format-sys-morphism-sys-target a)
+          any/c)])
+    [_ (a b)
+      (snippet-format-sys-morphism-sys/c
+        (ok/c #/snippet-format-sys-morphism-sys-source a)
+        (ok/c #/snippet-format-sys-morphism-sys-target b))])
   (chain-two-snippet-format-sys-morphism-sys a b))
 
 
@@ -2128,9 +2139,12 @@
       ; category-sys-morphism-chain-two
       (fn cs a b c ab bc
         (snippet-format-sys-morphism-sys-chain-two ab bc)))))
+(ascribe-own-contract snippet-format-sys-category-sys?
+  (-> any/c boolean?))
 
 
-(define (snippet-format-sys-endofunctor-sys? v)
+(define/own-contract (snippet-format-sys-endofunctor-sys? v)
+  (-> any/c boolean?)
   (
     (flat-contract-predicate
       (functor-sys/c
@@ -2138,10 +2152,26 @@
         snippet-format-sys-category-sys?))
     v))
 
-(define
+(define/own-contract
   (make-snippet-format-sys-endofunctor-sys-impl-from-apply
     apply-to-snippet-format-sys
     apply-to-snippet-format-sys-morphism-sys)
+  (->
+    (-> snippet-format-sys-endofunctor-sys? snippet-format-sys?
+      snippet-format-sys?)
+    (->i
+      (
+        [es snippet-format-sys-endofunctor-sys?]
+        [ms snippet-format-sys-morphism-sys?])
+      [_ (es ms)
+        (snippet-format-sys-morphism-sys/c
+          (ok/c
+            (functor-sys-apply-to-object es
+              (snippet-format-sys-morphism-sys-source ms)))
+          (ok/c
+            (functor-sys-apply-to-object es
+              (snippet-format-sys-morphism-sys-target ms))))])
+    functor-sys-impl?)
   (make-functor-sys-impl-from-apply
     ; functor-sys-source
     (fn fs #/snippet-format-sys-category-sys)

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -119,7 +119,8 @@
   get/build-late-neg-projection struct-type-property/c)
 (require #/only-in racket/contract/base
   -> ->i and/c any any/c contract? contract-name flat-contract?
-  flat-contract-predicate list/c listof none/c or/c rename-contract)
+  flat-contract-predicate list/c listof none/c not/c or/c
+  rename-contract)
 (require #/only-in racket/contract/combinator
   blame-add-context coerce-contract contract-first-order-passes?
   make-contract make-flat-contract raise-blame-error)

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -3060,9 +3060,9 @@
     (define/contract (hypertee-furl dim-sys coil)
       (->i
         (
-          [dim-sys dim-sys?]
-          [coil (dim-sys) (hypertee-coil/c dim-sys)])
-        [_ hypertee?])
+          [ds dim-sys?]
+          [coil (ds) (hypertee-coil/c ds)])
+        [_ (ds) (hypertee/c ds)])
       (unguarded-hypertee-furl-orig dim-sys coil))
     hypertee-furl))
 #;

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -188,17 +188,17 @@
 
 (provide
   unselected)
-(provide #/shim-contract-out
-  [unselected? (-> any/c boolean?)]
-  [unselected-value (-> unselected? any/c)])
+(provide #/own-contract-out
+  unselected?
+  unselected-value)
 (provide
   selected)
-(provide #/shim-contract-out
-  [selected? (-> any/c boolean?)]
-  [selected-value (-> selected? any/c)]
-  [selectable? (-> any/c boolean?)]
-  [selectable/c (-> contract? contract? contract?)]
-  [selectable-map (-> selectable? (-> any/c any/c) selectable?)])
+(provide #/own-contract-out
+  selected?
+  selected-value
+  selectable?
+  selectable/c
+  selectable-map)
 ; TODO DEBUGGABILITY: Provide a contract-protected version instead.
 ; We're currently defining this as a macro instead of a function, to
 ; help with debugging this file, but when the debug scaffolding is
@@ -213,459 +213,61 @@
 ; See the note on the `snippet-sys-snippet-degree` macro export.
 (provide
   snippet-sys-snippet-splice)
-(provide #/shim-contract-out
-  [snippet-sys? (-> any/c boolean?)]
-  [snippet-sys-impl? (-> any/c boolean?)]
-  [snippet-sys-snippet/c (-> snippet-sys? flat-contract?)]
-  [snippet-sys-dim-sys (-> snippet-sys? dim-sys?)]
-  [snippet-sys-shape-snippet-sys (-> snippet-sys? snippet-sys?)]
+(provide #/own-contract-out
+  snippet-sys?
+  snippet-sys-impl?
+  snippet-sys-snippet/c
+  snippet-sys-dim-sys
+  snippet-sys-shape-snippet-sys
   ; TODO DEBUGGABILITY: Provide a contract-protected version like this
   ; commented-out export instead. See the note on the
   ; `snippet-sys-snippet-degree` macro export.
   #;
-  [snippet-sys-snippet-degree
-    (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
-      [_ (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)])]
-  [snippet-sys-snippet-with-degree/c
-    (-> snippet-sys? flat-contract? flat-contract?)]
-  [snippet-sys-snippet-with-degree</c
-    (->i
-      (
-        [ss snippet-sys?]
-        [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)])
-      [_ flat-contract?])]
-  [snippet-sys-snippet-with-degree=/c
-    (->i
-      (
-        [ss snippet-sys?]
-        [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)])
-      [_ flat-contract?])]
-  [snippet-sys-snippet-with-0<degree/c
-    (-> snippet-sys? flat-contract?)]
-  [snippet-sys-snippetof/ob-c
-    (->i
-      (
-        [ss snippet-sys?]
-        [ob obstinacy?]
-        [h-to-value/c (ss ob)
-          ; NOTE: Via the definition of
-          ; `snippet-sys-unlabeled-shape/c`,
-          ; `snippet-sys-snippetof/ob-c` basically appears in its own
-          ; contract.
-          (-> (snippet-sys-unlabeled-shape/c ss)
-            (obstinacy-contract/c ob))])
-      [_ (ob) (obstinacy-contract/c ob)])]
-  [snippet-sys-unlabeled-snippet/c (-> snippet-sys? flat-contract?)]
-  [snippet-sys-unlabeled-shape/c (-> snippet-sys? flat-contract?)]
-  [snippet-sys-snippet-zip-selective/ob-c
-    (->i
-      (
-        [ss snippet-sys?]
-        [ob obstinacy?]
-        [shape (ss)
-          (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)]
-        [check-subject-hv? (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c boolean?)]
-        [hvv-to-subject-v/c (ss ob)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c
-            (obstinacy-contract/c ob))])
-      [_ (ob) (obstinacy-contract/c ob)])]
-  [snippet-sys-snippet-fitting-shape/c
-    (->i
-      (
-        [ss snippet-sys?]
-        [shape (ss) (snippet-sys-unlabeled-shape/c ss)])
-      [_ flat-contract?])]
-  [snippet-sys-shape->snippet
-    (->i
-      (
-        [ss snippet-sys?]
-        [shape (ss)
-          (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)])
-      [_ (ss shape)
-        (snippet-sys-snippet-with-degree=/c ss
-          (snippet-sys-snippet-degree
-            (snippet-sys-shape-snippet-sys ss)
-            shape))])]
-  [snippet-sys-snippet->maybe-shape
-    (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
-      [_ (ss snippet)
-        (maybe/c
-          (snippet-sys-snippet/c
-            (snippet-sys-shape-snippet-sys ss)))])]
-  ; TODO: See if the result contract should be more specific. The
-  ; result should always exist if the snippet already has the given
-  ; degree, and it should always exist if the given degree is greater
-  ; than that degree and that degree is nonzero.
-  [snippet-sys-snippet-set-degree-maybe
-    (->i
-      (
-        [ss snippet-sys?]
-        [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
-        [snippet (ss) (snippet-sys-snippet/c ss)])
-      [_ (ss degree)
-        (maybe/c #/snippet-sys-snippet-with-degree=/c ss degree)])]
+  snippet-sys-snippet-degree
+  snippet-sys-snippet-with-degree/c
+  snippet-sys-snippet-with-degree</c
+  snippet-sys-snippet-with-degree=/c
+  snippet-sys-snippet-with-0<degree/c
+  snippet-sys-snippetof/ob-c
+  snippet-sys-unlabeled-snippet/c
+  snippet-sys-unlabeled-shape/c
+  snippet-sys-snippet-zip-selective/ob-c
+  snippet-sys-snippet-fitting-shape/c
+  snippet-sys-shape->snippet
+  snippet-sys-snippet->maybe-shape
+  snippet-sys-snippet-set-degree-maybe
   ; TODO DEBUGGABILITY: Provide a contract-protected version like this
   ; commented-out export instead. See the note on the
   ; `snippet-sys-snippet-degree` macro export.
   #;
-  [snippet-sys-snippet-done
-    (->i
-      (
-        [ss snippet-sys?]
-        [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
-        [shape (ss degree)
-          (snippet-sys-snippet-with-degree</c
-            (snippet-sys-shape-snippet-sys ss)
-            degree)]
-        [data any/c])
-      [_ (ss degree) (snippet-sys-snippet-with-degree=/c ss degree)])]
-  [snippet-sys-snippet-undone
-    (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
-      [_ (ss snippet)
-        (maybe/c #/list/c
-          (dim-sys-dim/c #/snippet-sys-dim-sys ss)
-          (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)
-          any/c)])]
-  [snippet-sys-snippet-select-everything
-    (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
-      [_ (ss snippet)
-        (and/c
-          (snippet-sys-snippet-with-degree=/c ss
-            (snippet-sys-snippet-degree ss snippet))
-          (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-            selected?))])]
+  snippet-sys-snippet-done
+  snippet-sys-snippet-undone
+  snippet-sys-snippet-select-everything
   ; TODO DEBUGGABILITY: Provide a contract-protected version like this
   ; commented-out export instead. See the note on the
   ; `snippet-sys-snippet-degree` macro export.
   #;
-  [snippet-sys-snippet-splice
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [hv-to-splice (ss snippet)
-          (w- has-d/c
-            (snippet-sys-snippet-with-degree=/c ss
-              (snippet-sys-snippet-degree ss snippet))
-          #/->i
-            (
-              [prefix-hole (snippet-sys-unlabeled-shape/c ss)]
-              [data any/c])
-            [_ (prefix-hole)
-              (maybe/c #/selectable/c any/c #/and/c
-                has-d/c
-                (snippet-sys-snippet-fitting-shape/c ss
-                  prefix-hole))])])
-      [_ (ss snippet)
-        (maybe/c
-          (snippet-sys-snippet-with-degree=/c ss
-            (snippet-sys-snippet-degree ss snippet)))])]
-  [snippet-sys-snippet-zip-map-selective
-    (->i
-      (
-        [ss snippet-sys?]
-        [shape (ss)
-          (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)]
-        [snippet (ss)
-          (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-            selectable?)]
-        [hvv-to-maybe-v (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c maybe?)])
-      [_ (ss snippet)
-        (maybe/c
-          (snippet-sys-snippet-with-degree=/c ss
-            (snippet-sys-snippet-degree ss snippet)))])]
-  [snippet-sys-snippet-zip-map
-    (->i
-      (
-        [ss snippet-sys?]
-        [shape (ss)
-          (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [hvv-to-maybe-v (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c maybe?)])
-      [_ (ss snippet)
-        (maybe/c
-          (snippet-sys-snippet-with-degree=/c ss
-            (snippet-sys-snippet-degree ss snippet)))])]
-  [snippet-sys-snippet-any?
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [check-hv? (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c boolean?)])
-      [_ boolean?])]
-  [snippet-sys-snippet-all?
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [check-hv? (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c boolean?)])
-      [_ boolean?])]
-  [snippet-sys-snippet-each
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [visit-hv (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c any)])
-      [_ void?])]
-  [snippet-sys-snippet-map-maybe
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [hv-to-maybe-v (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c maybe?)])
-      [_ (ss snippet)
-        (maybe/c
-          (snippet-sys-snippet-with-degree=/c ss
-            (snippet-sys-snippet-degree ss snippet)))])]
-  [snippet-sys-snippet-map
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [hv-to-v (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c)])
-      [_ (ss snippet)
-        (snippet-sys-snippet-with-degree=/c ss
-          (snippet-sys-snippet-degree ss snippet))])]
-  [snippet-sys-snippet-map-selective
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss)
-          (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-            selectable?)]
-        [hv-to-v (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c)])
-      [_ (ss snippet)
-        (snippet-sys-snippet-with-degree=/c ss
-          (snippet-sys-snippet-degree ss snippet))])]
-  [snippet-sys-snippet-select
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [check-hv? (ss)
-          (-> (snippet-sys-unlabeled-shape/c ss) any/c boolean?)])
-      [_ (ss snippet)
-        (and/c
-          (snippet-sys-snippet-with-degree=/c ss
-            (snippet-sys-snippet-degree ss snippet))
-          (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-            selectable?))])]
-  [snippet-sys-snippet-select-if-degree
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss) (snippet-sys-snippet/c ss)]
-        [check-degree? (ss)
-          (-> (dim-sys-dim/c #/snippet-sys-dim-sys ss) boolean?)])
-      [_ (ss snippet)
-        (and/c
-          (snippet-sys-snippet-with-degree=/c ss
-            (snippet-sys-snippet-degree ss snippet))
-          (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-            selectable?))])]
-  [snippet-sys-snippet-select-if-degree<
-    (->i
-      (
-        [ss snippet-sys?]
-        [degreee (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
-        [snippet (ss) (snippet-sys-snippet/c ss)])
-      [_ (ss snippet)
-        (and/c
-          (snippet-sys-snippet-with-degree=/c ss
-            (snippet-sys-snippet-degree ss snippet))
-          (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-            selectable?))])]
-  [snippet-sys-snippet-bind-selective
-    (->i
-      (
-        [ss snippet-sys?]
-        [prefix (ss) (snippet-sys-snippet/c ss)]
-        [hv-to-suffix (ss prefix)
-          (w- has-d/c
-            (snippet-sys-snippet-with-degree=/c ss
-              (snippet-sys-snippet-degree ss prefix))
-          #/->i
-            (
-              [prefix-hole (snippet-sys-unlabeled-shape/c ss)]
-              [data any/c])
-            [_ (prefix-hole)
-              (selectable/c any/c #/and/c
-                has-d/c
-                (snippet-sys-snippet-fitting-shape/c ss
-                  prefix-hole))])])
-      [_ (ss prefix)
-        (snippet-sys-snippet-with-degree=/c ss
-          (snippet-sys-snippet-degree ss prefix))])]
-  [snippet-sys-snippet-join-selective
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss)
-          (and/c (snippet-sys-snippet/c ss)
-          #/by-own-method/c #:obstinacy (flat-obstinacy) snippet
-          #/w- has-d/c
-            (snippet-sys-snippet-with-degree=/c ss
-              (snippet-sys-snippet-degree ss snippet))
-          #/snippet-sys-snippetof/ob-c ss (flat-obstinacy)
-            (fn prefix-hole
-              (selectable/c any/c #/and/c
-                has-d/c
-                (snippet-sys-snippet-fitting-shape/c
-                  ss prefix-hole))))])
-      [_ (ss snippet)
-        (snippet-sys-snippet-with-degree=/c ss
-          (snippet-sys-snippet-degree ss snippet))])]
-  [snippet-sys-snippet-bind
-    (->i
-      (
-        [ss snippet-sys?]
-        [prefix (ss) (snippet-sys-snippet/c ss)]
-        [hv-to-suffix (ss prefix)
-          (w- has-d/c
-            (snippet-sys-snippet-with-degree=/c ss
-              (snippet-sys-snippet-degree ss prefix))
-          #/->i
-            (
-              [prefix-hole (snippet-sys-unlabeled-shape/c ss)]
-              [data any/c])
-            [_ (prefix-hole)
-              (and/c
-                has-d/c
-                (snippet-sys-snippet-fitting-shape/c ss
-                  prefix-hole))])])
-      [_ (ss prefix)
-        (snippet-sys-snippet-with-degree=/c ss
-          (snippet-sys-snippet-degree ss prefix))])]
-  [snippet-sys-snippet-join
-    (->i
-      (
-        [ss snippet-sys?]
-        [snippet (ss)
-          (and/c (snippet-sys-snippet/c ss)
-          #/by-own-method/c #:obstinacy (flat-obstinacy) snippet
-          #/w- has-d/c
-            (snippet-sys-snippet-with-degree=/c ss
-              (snippet-sys-snippet-degree ss snippet))
-          #/snippet-sys-snippetof/ob-c ss (flat-obstinacy)
-            (fn prefix-hole
-              (and/c
-                has-d/c
-                (snippet-sys-snippet-fitting-shape/c
-                  ss prefix-hole))))])
-      [_ (ss snippet)
-        (snippet-sys-snippet-with-degree=/c ss
-          (snippet-sys-snippet-degree ss snippet))])]
-  [prop:snippet-sys (struct-type-property/c snippet-sys-impl?)]
+  snippet-sys-snippet-splice
+  snippet-sys-snippet-zip-map-selective
+  snippet-sys-snippet-zip-map
+  snippet-sys-snippet-any?
+  snippet-sys-snippet-all?
+  snippet-sys-snippet-each
+  snippet-sys-snippet-map-maybe
+  snippet-sys-snippet-map
+  snippet-sys-snippet-map-selective
+  snippet-sys-snippet-select
+  snippet-sys-snippet-select-if-degree
+  snippet-sys-snippet-select-if-degree<
+  snippet-sys-snippet-bind-selective
+  snippet-sys-snippet-join-selective
+  snippet-sys-snippet-bind
+  snippet-sys-snippet-join
+  prop:snippet-sys
   ; TODO: See if we can come up with a better name or interface for
   ; this.
-  [make-snippet-sys-impl-from-various-1
-    (->
-      ; snippet-sys-snippet/c
-      (-> snippet-sys? flat-contract?)
-      ; snippet-sys-dim-sys
-      (-> snippet-sys? dim-sys?)
-      ; snippet-sys-shape-snippet-sys
-      (-> snippet-sys? snippet-sys?)
-      ; snippet-sys-snippet-degree
-      (->i
-        ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
-        [_ (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)])
-      ; snippet-sys-shape->snippet
-      (->i
-        (
-          [ss snippet-sys?]
-          [shape (ss)
-            (snippet-sys-snippet/c
-              (snippet-sys-shape-snippet-sys ss))])
-        [_ (ss shape)
-          (snippet-sys-snippet-with-degree=/c ss
-          #/snippet-sys-snippet-degree
-            (snippet-sys-shape-snippet-sys ss)
-            shape)])
-      ; snippet-sys-snippet->maybe-shape
-      (->i
-        ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
-        [_ (ss snippet)
-          (maybe/c
-            (snippet-sys-snippet/c
-              (snippet-sys-shape-snippet-sys ss)))])
-      ; snippet-sys-snippet-set-degree-maybe
-      (->i
-        (
-          [ss snippet-sys?]
-          [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
-          [snippet (ss) (snippet-sys-snippet/c ss)])
-        [_ (ss degree)
-          (maybe/c #/snippet-sys-snippet-with-degree=/c ss degree)])
-      ; snippet-sys-snippet-done
-      (->i
-        (
-          [ss snippet-sys?]
-          [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
-          [shape (ss degree)
-            (snippet-sys-snippet-with-degree</c
-              (snippet-sys-shape-snippet-sys ss)
-              degree)]
-          [data any/c])
-        [_ (ss degree)
-          (snippet-sys-snippet-with-degree=/c ss degree)])
-      ; snippet-sys-snippet-undone
-      (->i
-        ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
-        [_ (ss snippet)
-          (maybe/c #/list/c
-            (dim-sys-dim/c #/snippet-sys-dim-sys ss)
-            (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)
-            any/c)])
-      ; snippet-sys-snippet-splice
-      (->i
-        (
-          [ss snippet-sys?]
-          [snippet (ss) (snippet-sys-snippet/c ss)]
-          [hv-to-splice (ss snippet)
-            (w- has-d/c
-              (snippet-sys-snippet-with-degree=/c ss
-                (snippet-sys-snippet-degree ss snippet))
-            #/->i
-              (
-                [prefix-hole (snippet-sys-unlabeled-shape/c ss)]
-                [data any/c])
-              [_ (prefix-hole)
-                (maybe/c #/selectable/c any/c #/and/c
-                  has-d/c
-                  (snippet-sys-snippet-fitting-shape/c ss
-                    prefix-hole))])])
-        [_ (ss snippet)
-          (maybe/c
-            (snippet-sys-snippet-with-degree=/c ss
-              (snippet-sys-snippet-degree ss snippet)))])
-      ; snippet-sys-snippet-zip-map-selective
-      (->i
-        (
-          [ss snippet-sys?]
-          [shape (ss)
-            (snippet-sys-snippet/c
-              (snippet-sys-shape-snippet-sys ss))]
-          [snippet (ss)
-            (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-              selectable?)]
-          [hvv-to-maybe-v (ss)
-            (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c
-              maybe?)])
-        [_ (ss snippet)
-          (maybe/c
-            (snippet-sys-snippet-with-degree=/c ss
-            #/snippet-sys-snippet-degree ss snippet))])
-      snippet-sys-impl?)]
+  make-snippet-sys-impl-from-various-1)
+(provide #/shim-contract-out
   
   [snippet-sys-morphism-sys? (-> any/c boolean?)]
   [snippet-sys-morphism-sys-impl? (-> any/c boolean?)]
@@ -1152,16 +754,22 @@
   (unselected? unselected-value)
   unselected
   'unselected (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract unselected? (-> any/c boolean?))
+(ascribe-own-contract unselected-value (-> unselected? any/c))
 
 (define-imitation-simple-struct
   (selected? selected-value)
   selected
   'selected (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract selected? (-> any/c boolean?))
+(ascribe-own-contract selected-value (-> selected? any/c))
 
-(define (selectable? v)
+(define/own-contract (selectable? v)
+  (-> any/c boolean?)
   (or (unselected? v) (selected? v)))
 
-(define (selectable/c unselected/c selected/c)
+(define/own-contract (selectable/c unselected/c selected/c)
+  (-> contract? contract? contract?)
   (w- unselected/c (coerce-contract 'selectable/c unselected/c)
   #/w- selected/c (coerce-contract 'selectable/c selected/c)
   #/rename-contract
@@ -1172,7 +780,8 @@
        ,(contract-name unselected/c)
        ,(contract-name selected/c))))
 
-(define (selectable-map s v-to-v)
+(define/own-contract (selectable-map s v-to-v)
+  (-> selectable? (-> any/c any/c) selectable?)
   (mat s (unselected v) (unselected v)
   #/dissect s (selected v) (selected #/v-to-v v)))
 
@@ -1191,6 +800,206 @@
   (#:method snippet-sys-snippet-zip-map-selective (#:this) () () ())
   prop:snippet-sys make-snippet-sys-impl-from-various-1
   'snippet-sys 'snippet-sys-impl (list))
+(ascribe-own-contract snippet-sys? (-> any/c boolean?))
+(ascribe-own-contract snippet-sys-impl? (-> any/c boolean?))
+(ascribe-own-contract snippet-sys-snippet/c
+  (-> snippet-sys? flat-contract?))
+(ascribe-own-contract snippet-sys-dim-sys (-> snippet-sys? dim-sys?))
+(ascribe-own-contract snippet-sys-shape-snippet-sys
+  (-> snippet-sys? snippet-sys?))
+; TODO DEBUGGABILITY: Provide a contract-protected version like this
+; commented-out ascription instead. See the note on the
+; `snippet-sys-snippet-degree` macro export.
+#;
+(ascribe-own-contract snippet-sys-snippet-degree
+  (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
+    [_ (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]))
+(ascribe-own-contract snippet-sys-shape->snippet
+  (->i
+    (
+      [ss snippet-sys?]
+      [shape (ss)
+        (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)])
+    [_ (ss shape)
+      (snippet-sys-snippet-with-degree=/c ss
+        (snippet-sys-snippet-degree
+          (snippet-sys-shape-snippet-sys ss)
+          shape))]))
+(ascribe-own-contract snippet-sys-snippet->maybe-shape
+  (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
+    [_ (ss snippet)
+      (maybe/c
+        (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss))]))
+(ascribe-own-contract snippet-sys-snippet-set-degree-maybe
+  ; TODO SPECIFIC: See if the result contract should be more specific.
+  ; The result should always exist if the snippet already has the
+  ; given degree, and it should always exist if the given degree is
+  ; greater than that degree and that degree is nonzero.
+  (->i
+    (
+      [ss snippet-sys?]
+      [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
+      [snippet (ss) (snippet-sys-snippet/c ss)])
+    [_ (ss degree)
+      (maybe/c #/snippet-sys-snippet-with-degree=/c ss degree)]))
+; TODO DEBUGGABILITY: Provide a contract-protected version like this
+; commented-out ascription instead. See the note on the
+; `snippet-sys-snippet-degree` macro export.
+#;
+(ascribe-own-contract snippet-sys-snippet-done
+  (->i
+    (
+      [ss snippet-sys?]
+      [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
+      [shape (ss degree)
+        (snippet-sys-snippet-with-degree</c
+          (snippet-sys-shape-snippet-sys ss)
+          degree)]
+      [data any/c])
+    [_ (ss degree) (snippet-sys-snippet-with-degree=/c ss degree)]))
+(ascribe-own-contract snippet-sys-snippet-undone
+  (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
+    [_ (ss snippet)
+      (maybe/c #/list/c
+        (dim-sys-dim/c #/snippet-sys-dim-sys ss)
+        (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)
+        any/c)]))
+; TODO DEBUGGABILITY: Provide a contract-protected version like this
+; commented-out ascription instead. See the note on the
+; `snippet-sys-snippet-degree` macro export.
+#;
+(ascribe-own-contract snippet-sys-snippet-splice
+  (->i
+    (
+      [ss snippet-sys?]
+      [snippet (ss) (snippet-sys-snippet/c ss)]
+      [hv-to-splice (ss snippet)
+        (w- has-d/c
+          (snippet-sys-snippet-with-degree=/c ss
+            (snippet-sys-snippet-degree ss snippet))
+        #/->i
+          (
+            [prefix-hole (snippet-sys-unlabeled-shape/c ss)]
+            [data any/c])
+          [_ (prefix-hole)
+            (maybe/c #/selectable/c any/c #/and/c
+              has-d/c
+              (snippet-sys-snippet-fitting-shape/c ss
+                prefix-hole))])])
+    [_ (ss snippet)
+      (maybe/c
+        (snippet-sys-snippet-with-degree=/c ss
+          (snippet-sys-snippet-degree ss snippet)))]))
+(ascribe-own-contract snippet-sys-snippet-zip-map-selective
+  (->i
+    (
+      [ss snippet-sys?]
+      [shape (ss)
+        (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)]
+      [snippet (ss)
+        (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+          selectable?)]
+      [hvv-to-maybe-v (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c maybe?)])
+    [_ (ss snippet)
+      (maybe/c
+        (snippet-sys-snippet-with-degree=/c ss
+          (snippet-sys-snippet-degree ss snippet)))]))
+(ascribe-own-contract prop:snippet-sys
+  (struct-type-property/c snippet-sys-impl?))
+(ascribe-own-contract make-snippet-sys-impl-from-various-1
+  (->
+    ; snippet-sys-snippet/c
+    (-> snippet-sys? flat-contract?)
+    ; snippet-sys-dim-sys
+    (-> snippet-sys? dim-sys?)
+    ; snippet-sys-shape-snippet-sys
+    (-> snippet-sys? snippet-sys?)
+    ; snippet-sys-snippet-degree
+    (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
+      [_ (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)])
+    ; snippet-sys-shape->snippet
+    (->i
+      (
+        [ss snippet-sys?]
+        [shape (ss)
+          (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)])
+      [_ (ss shape)
+        (snippet-sys-snippet-with-degree=/c ss
+        #/snippet-sys-snippet-degree
+          (snippet-sys-shape-snippet-sys ss)
+          shape)])
+    ; snippet-sys-snippet->maybe-shape
+    (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
+      [_ (ss snippet)
+        (maybe/c
+          (snippet-sys-snippet/c
+            (snippet-sys-shape-snippet-sys ss)))])
+    ; snippet-sys-snippet-set-degree-maybe
+    (->i
+      (
+        [ss snippet-sys?]
+        [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
+        [snippet (ss) (snippet-sys-snippet/c ss)])
+      [_ (ss degree)
+        (maybe/c #/snippet-sys-snippet-with-degree=/c ss degree)])
+    ; snippet-sys-snippet-done
+    (->i
+      (
+        [ss snippet-sys?]
+        [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
+        [shape (ss degree)
+          (snippet-sys-snippet-with-degree</c
+            (snippet-sys-shape-snippet-sys ss)
+            degree)]
+        [data any/c])
+      [_ (ss degree) (snippet-sys-snippet-with-degree=/c ss degree)])
+    ; snippet-sys-snippet-undone
+    (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
+      [_ (ss snippet)
+        (maybe/c #/list/c
+          (dim-sys-dim/c #/snippet-sys-dim-sys ss)
+          (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)
+          any/c)])
+    ; snippet-sys-snippet-splice
+    (->i
+      (
+        [ss snippet-sys?]
+        [snippet (ss) (snippet-sys-snippet/c ss)]
+        [hv-to-splice (ss snippet)
+          (w- has-d/c
+            (snippet-sys-snippet-with-degree=/c ss
+              (snippet-sys-snippet-degree ss snippet))
+          #/->i
+            (
+              [prefix-hole (snippet-sys-unlabeled-shape/c ss)]
+              [data any/c])
+            [_ (prefix-hole)
+              (maybe/c #/selectable/c any/c #/and/c
+                has-d/c
+                (snippet-sys-snippet-fitting-shape/c ss
+                  prefix-hole))])])
+      [_ (ss snippet)
+        (maybe/c
+          (snippet-sys-snippet-with-degree=/c ss
+            (snippet-sys-snippet-degree ss snippet)))])
+    ; snippet-sys-snippet-zip-map-selective
+    (->i
+      (
+        [ss snippet-sys?]
+        [shape (ss)
+          (snippet-sys-snippet/c
+            (snippet-sys-shape-snippet-sys ss))]
+        [snippet (ss)
+          (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+            selectable?)]
+        [hvv-to-maybe-v (ss)
+          (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c maybe?)])
+      [_ (ss snippet)
+        (maybe/c
+          (snippet-sys-snippet-with-degree=/c ss
+          #/snippet-sys-snippet-degree ss snippet))])
+    snippet-sys-impl?))
 
 ; NOTE DEBUGGABILITY: This is here for debugging. If not for
 ; debugging, we would rename `unguarded-snippet-sys-snippet-degree` to
@@ -1276,7 +1085,14 @@
 ; TODO: See if we should have a way to implement this that doesn't
 ; involve constructing another snippet along the way, since we just
 ; end up ignoring it.
-(define (snippet-sys-snippet-all? ss snippet check-hv?)
+(define/own-contract (snippet-sys-snippet-all? ss snippet check-hv?)
+  (->i
+    (
+      [ss snippet-sys?]
+      [snippet (ss) (snippet-sys-snippet/c ss)]
+      [check-hv? (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c boolean?)])
+    [_ boolean?])
   (dlog 'zn1 check-hv?
   #/just? #/snippet-sys-snippet-splice ss snippet #/fn hole data
     (dlog 'zn2
@@ -1285,19 +1101,44 @@
       (nothing))))
 
 ; TODO: Use the things that use this.
-(define (snippet-sys-snippet-any? ss snippet check-hv?)
+(define/own-contract (snippet-sys-snippet-any? ss snippet check-hv?)
+  (->i
+    (
+      [ss snippet-sys?]
+      [snippet (ss) (snippet-sys-snippet/c ss)]
+      [check-hv? (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c boolean?)])
+    [_ boolean?])
   (not #/snippet-sys-snippet-all? ss snippet #/fn hole data
     (not #/check-hv? hole data)))
 
 ; TODO: Use the things that use this.
-(define (snippet-sys-snippet-each ss snippet visit-hv)
+(define/own-contract (snippet-sys-snippet-each ss snippet visit-hv)
+  (->i
+    (
+      [ss snippet-sys?]
+      [snippet (ss) (snippet-sys-snippet/c ss)]
+      [visit-hv (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c any)])
+    [_ void?])
   (begin
     (snippet-sys-snippet-all? ss snippet #/fn hole data
       (begin (visit-hv hole data)
         #t))
   #/void))
 
-(define (snippet-sys-snippet-map-maybe ss snippet hv-to-maybe-v)
+(define/own-contract
+  (snippet-sys-snippet-map-maybe ss snippet hv-to-maybe-v)
+  (->i
+    (
+      [ss snippet-sys?]
+      [snippet (ss) (snippet-sys-snippet/c ss)]
+      [hv-to-maybe-v (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c maybe?)])
+    [_ (ss snippet)
+      (maybe/c
+        (snippet-sys-snippet-with-degree=/c ss
+          (snippet-sys-snippet-degree ss snippet)))])
   (snippet-sys-snippet-splice ss snippet #/fn hole data
     (dlog 'o1 hv-to-maybe-v
     #/maybe-map (hv-to-maybe-v hole data) #/fn data
@@ -1326,13 +1167,32 @@
 (ascribe-own-contract snippet-sys-snippet-map
   snippet-sys-snippet-map/explicit-sig-c)
 
-(define (snippet-sys-snippet-select ss snippet check-hv?)
+(define/own-contract (snippet-sys-snippet-select ss snippet check-hv?)
+  (->i
+    (
+      [ss snippet-sys?]
+      [snippet (ss) (snippet-sys-snippet/c ss)]
+      [check-hv? (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c boolean?)])
+    [_ (ss snippet)
+      (and/c
+        (snippet-sys-snippet-with-degree=/c ss
+          (snippet-sys-snippet-degree ss snippet))
+        (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+          selectable?))])
   (snippet-sys-snippet-map ss snippet #/fn hole data
     (if (check-hv? hole data)
       (selected data)
       (unselected data))))
 
-(define (snippet-sys-snippet-select-everything ss snippet)
+(define/own-contract (snippet-sys-snippet-select-everything ss snippet)
+  (->i ([ss snippet-sys?] [snippet (ss) (snippet-sys-snippet/c ss)])
+    [_ (ss snippet)
+      (and/c
+        (snippet-sys-snippet-with-degree=/c ss
+          (snippet-sys-snippet-degree ss snippet))
+        (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+          selected?))])
   (snippet-sys-snippet-select ss snippet #/fn hole data #t))
 
 ; TODO: See if this should have the question mark in its name.
@@ -1361,7 +1221,8 @@
     #/dissect data (selected #/list shape-data snippet-data)
     #/check-hvv? hole shape-data snippet-data)))
 
-(define (snippet-sys-snippet-with-degree/c ss degree/c)
+(define/own-contract (snippet-sys-snippet-with-degree/c ss degree/c)
+  (-> snippet-sys? flat-contract? flat-contract?)
   (w- degree/c
     (coerce-contract 'snippet-sys-snippet-with-degree/c degree/c)
   #/w- name
@@ -1395,25 +1256,47 @@
             missing-party)
           v)))))
 
-(define (snippet-sys-snippet-with-degree</c ss degree)
+(define/own-contract (snippet-sys-snippet-with-degree</c ss degree)
+  (->i
+    (
+      [ss snippet-sys?]
+      [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)])
+    [_ flat-contract?])
   (rename-contract
     (snippet-sys-snippet-with-degree/c ss
       (dim-sys-dim</c (snippet-sys-dim-sys ss) degree))
     `(snippet-sys-snippet-with-degree</c ,ss ,degree)))
 
-(define (snippet-sys-snippet-with-degree=/c ss degree)
+(define/own-contract (snippet-sys-snippet-with-degree=/c ss degree)
+  (->i
+    (
+      [ss snippet-sys?]
+      [degree (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)])
+    [_ flat-contract?])
   (rename-contract
     (snippet-sys-snippet-with-degree/c ss
       (dim-sys-dim=/c (snippet-sys-dim-sys ss) degree))
     `(snippet-sys-snippet-with-degree=/c ,ss ,degree)))
 
-(define (snippet-sys-snippet-with-0<degree/c ss)
+(define/own-contract (snippet-sys-snippet-with-0<degree/c ss)
+  (-> snippet-sys? flat-contract?)
   (rename-contract
     (snippet-sys-snippet-with-degree/c ss
       (dim-sys-0<dim/c #/snippet-sys-dim-sys ss))
     `(snippet-sys-snippet-with-0<degree/c ,ss)))
 
-(define (snippet-sys-snippetof/ob-c ss ob h-to-value/c)
+(define/own-contract (snippet-sys-snippetof/ob-c ss ob h-to-value/c)
+  (->i
+    (
+      [ss snippet-sys?]
+      [ob obstinacy?]
+      [h-to-value/c (ss ob)
+        ; NOTE: Via the definition of `snippet-sys-unlabeled-shape/c`,
+        ; `snippet-sys-snippetof/ob-c` basically appears in its own
+        ; contract.
+        (-> (snippet-sys-unlabeled-shape/c ss)
+          (obstinacy-contract/c ob))])
+    [_ (ob) (obstinacy-contract/c ob)])
   (w- name `(snippet-sys-snippetof/ob-c ,ss ,ob ,h-to-value/c)
   #/w- coerce
     (obstinacy-get-coerce-contract-for-id ob
@@ -1453,21 +1336,35 @@
             v)
           (snippet-sys-snippet-map ss v process-hole))))))
 
-(define (snippet-sys-unlabeled-snippet/c ss)
+(define/own-contract (snippet-sys-unlabeled-snippet/c ss)
+  (-> snippet-sys? flat-contract?)
   (rename-contract
     (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
       trivial?)
     `(snippet-sys-unlabeled-snippet/c ,ss)))
 
-(define (snippet-sys-unlabeled-shape/c ss)
+(define/own-contract (snippet-sys-unlabeled-shape/c ss)
+  (-> snippet-sys? flat-contract?)
   (rename-contract
     (snippet-sys-unlabeled-snippet/c
       (snippet-sys-shape-snippet-sys ss))
     `(snippet-sys-unlabeled-shape/c ,ss)))
 
-(define
+(define/own-contract
   (snippet-sys-snippet-zip-selective/ob-c
     ss ob shape check-subject-hv? hvv-to-subject-v/c)
+  (->i
+    (
+      [ss snippet-sys?]
+      [ob obstinacy?]
+      [shape (ss)
+        (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)]
+      [check-subject-hv? (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c boolean?)]
+      [hvv-to-subject-v/c (ss ob)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c
+          (obstinacy-contract/c ob))])
+    [_ (ob) (obstinacy-contract/c ob)])
   (w- name
     `(snippet-sys-snippet-zip-selective/ob-c
       ,ss ,ob ,shape ,check-subject-hv? ,hvv-to-subject-v/c)
@@ -1526,7 +1423,12 @@
           v
           result)))))
 
-(define (snippet-sys-snippet-fitting-shape/c ss shape)
+(define/own-contract (snippet-sys-snippet-fitting-shape/c ss shape)
+  (->i
+    (
+      [ss snippet-sys?]
+      [shape (ss) (snippet-sys-unlabeled-shape/c ss)])
+    [_ flat-contract?])
   (w- ds (snippet-sys-dim-sys ss)
   #/w- shape-ss (snippet-sys-shape-snippet-sys ss)
   #/w- shape-d (snippet-sys-snippet-degree shape-ss shape)
@@ -1543,14 +1445,38 @@
 
 
 ; TODO: Use the things that use this.
-(define
+(define/own-contract
   (snippet-sys-snippet-select-if-degree ss snippet check-degree?)
+  (->i
+    (
+      [ss snippet-sys?]
+      [snippet (ss) (snippet-sys-snippet/c ss)]
+      [check-degree? (ss)
+        (-> (dim-sys-dim/c #/snippet-sys-dim-sys ss) boolean?)])
+    [_ (ss snippet)
+      (and/c
+        (snippet-sys-snippet-with-degree=/c ss
+          (snippet-sys-snippet-degree ss snippet))
+        (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+          selectable?))])
   (w- shape-ss (snippet-sys-shape-snippet-sys ss)
   #/snippet-sys-snippet-select ss snippet #/fn hole data
     (check-degree? #/snippet-sys-snippet-degree shape-ss hole)))
 
 ; TODO: Use the things that use this.
-(define (snippet-sys-snippet-select-if-degree< ss degree snippet)
+(define/own-contract
+  (snippet-sys-snippet-select-if-degree< ss degree snippet)
+  (->i
+    (
+      [ss snippet-sys?]
+      [degreee (ss) (dim-sys-dim/c #/snippet-sys-dim-sys ss)]
+      [snippet (ss) (snippet-sys-snippet/c ss)])
+    [_ (ss snippet)
+      (and/c
+        (snippet-sys-snippet-with-degree=/c ss
+          (snippet-sys-snippet-degree ss snippet))
+        (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+          selectable?))])
   (w- ds (snippet-sys-dim-sys ss)
   #/snippet-sys-snippet-select-if-degree ss snippet #/fn actual-degree
     (dim-sys-dim<? ds actual-degree degree)))
@@ -2998,7 +2924,20 @@
 
 ; TODO: Export this.
 ; TODO: Use the things that use this.
-(define (snippet-sys-snippet-zip-map ss shape snippet hvv-to-maybe-v)
+(define/own-contract
+  (snippet-sys-snippet-zip-map ss shape snippet hvv-to-maybe-v)
+  (->i
+    (
+      [ss snippet-sys?]
+      [shape (ss)
+        (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)]
+      [snippet (ss) (snippet-sys-snippet/c ss)]
+      [hvv-to-maybe-v (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c maybe?)])
+    [_ (ss snippet)
+      (maybe/c
+        (snippet-sys-snippet-with-degree=/c ss
+          (snippet-sys-snippet-degree ss snippet)))])
   (w- snippet (snippet-sys-snippet-select-everything ss snippet)
   #/snippet-sys-snippet-zip-map-selective
     ss shape snippet hvv-to-maybe-v))
@@ -3038,7 +2977,19 @@
       (selected patch))))
 
 ; TODO: Use the things that use this.
-(define (snippet-sys-snippet-map-selective ss snippet hv-to-v)
+(define/own-contract
+  (snippet-sys-snippet-map-selective ss snippet hv-to-v)
+  (->i
+    (
+      [ss snippet-sys?]
+      [snippet (ss)
+        (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+          selectable?)]
+      [hv-to-v (ss)
+        (-> (snippet-sys-unlabeled-shape/c ss) any/c any/c)])
+    [_ (ss snippet)
+      (snippet-sys-snippet-with-degree=/c ss
+        (snippet-sys-snippet-degree ss snippet))])
   (snippet-sys-snippet-map ss snippet #/fn hole data
     (mat data (unselected data) data
     #/dissect data (selected data) (hv-to-v hole data))))

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -160,10 +160,6 @@
   make-atomic-set-element-sys-impl-from-contract ok/c
   prop:atomic-set-element-sys)
 
-; TODO NOW: Remove uses of `lathe-morphisms/private/shim`,
-; particularly including `shim-contract-out` and
-; `shim-recontract-out`.
-(require lathe-morphisms/private/shim)
 (require punctaffy/private/shim)
 (init-shim)
 (module+ private/hypertee
@@ -393,160 +389,81 @@
   ht-bracs
   hypertee-get-brackets)
 
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest? (-> any/c boolean?)]
-  [hypernest/c (-> snippet-format-sys? dim-sys? flat-contract?)]
-  [hypernestof/ob-c
-    (->i
-      (
-        [sfs snippet-format-sys?]
-        [ds dim-sys?]
-        [ob obstinacy?]
-        [b-to-value/c (sfs ds ob)
-          (w- ffdstsss (snippet-format-sys-functor sfs)
-          #/w- ss (functor-sys-apply-to-object ffdstsss ds)
-          #/-> (snippet-sys-unlabeled-shape/c ss)
-            (obstinacy-contract/c ob))]
-        [h-to-value/c (sfs ds ob)
-          (w- ffdstsss (snippet-format-sys-functor sfs)
-          #/w- ss (functor-sys-apply-to-object ffdstsss ds)
-          #/-> (snippet-sys-unlabeled-shape/c ss)
-            (obstinacy-contract/c ob))])
-      [_ (ob) (obstinacy-contract/c ob)])]
-  [hypernest-get-dim-sys (-> hypernest? dim-sys?)])
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest?
+  hypernest/c
+  hypernestof/ob-c
+  hypernest-get-dim-sys)
 (module+ private/hypernest #/provide
   hypernest-snippet-sys)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-snippet-sys? (-> any/c boolean?)]
-  [hypernest-snippet-sys-snippet-format-sys
-    (-> hypernest-snippet-sys? snippet-format-sys?)]
-  [hypernest-snippet-sys-dim-sys
-    (-> hypernest-snippet-sys? dim-sys?)])
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-snippet-sys?
+  hypernest-snippet-sys-snippet-format-sys
+  hypernest-snippet-sys-dim-sys)
 (module+ private/hypernest #/provide
   hypernest-snippet-format-sys)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-snippet-format-sys? (-> any/c boolean?)]
-  [hypernest-snippet-format-sys-original
-    (-> hypernest-snippet-format-sys? snippet-format-sys?)])
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-shape
-    (->i
-      (
-        [ss hypernest-snippet-sys?]
-        [hn (ss) (snippet-sys-snippet/c ss)])
-      [_ (ss)
-        (snippet-sys-snippet/c #/snippet-sys-shape-snippet-sys ss)])]
-  [hypernest-get-hole-zero-maybe
-    (->
-      (and/c hypernest?
-        (by-own-method/c #:obstinacy (flat-obstinacy) hn
-          (hypernest/c (hypertee-snippet-format-sys)
-            (hypernest-get-dim-sys hn))))
-      maybe?)]
-  [hypernest-join-list-and-tail-along-0
-    (->i
-      (
-        [ds dim-sys?]
-        [past-snippets (ds last-snippet)
-          (w- ss
-            (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
-          #/w- shape-ss (snippet-sys-shape-snippet-sys ss)
-          #/listof #/and/c
-            (snippet-sys-snippet-with-degree=/c ss
-              (snippet-sys-snippet-degree ss last-snippet))
-            (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-              (if
-                (dim-sys-dim=0? ds
-                  (snippet-sys-snippet-degree shape-ss hole))
-                trivial?
-                any/c)))]
-        [last-snippet (ds)
-          (w- ss
-            (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
-          #/snippet-sys-snippet-with-0<degree/c ss)])
-      [_ (ds last-snippet)
-        (w- ss
-          (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
-        #/snippet-sys-snippet-with-degree=/c ss
-          (snippet-sys-snippet-degree ss last-snippet))])])
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-snippet-format-sys?
+  hypernest-snippet-format-sys-original)
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-shape
+  hypernest-get-hole-zero-maybe
+  hypernest-join-list-and-tail-along-0)
 
 (module+ private/hypernest #/provide
   hypernest-coil-zero)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-coil-zero? (-> any/c boolean?)])
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-coil-zero?)
 (module+ private/hypernest #/provide
   hypernest-coil-hole)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-coil-hole? (-> any/c boolean?)]
-  [hypernest-coil-hole-overall-degree (-> hypernest-coil-hole? any/c)]
-  [hypernest-coil-hole-hole (-> hypernest-coil-hole? any/c)]
-  [hypernest-coil-hole-data (-> hypernest-coil-hole? any/c)]
-  [hypernest-coil-hole-tails-hypertee
-    (-> hypernest-coil-hole? any/c)])
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-coil-hole?
+  hypernest-coil-hole-overall-degree
+  hypernest-coil-hole-hole
+  hypernest-coil-hole-data
+  hypernest-coil-hole-tails-hypertee)
 (module+ private/hypernest #/provide
   hypernest-coil-bump)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-coil-bump? (-> any/c boolean?)]
-  [hypernest-coil-bump-overall-degree (-> hypernest-coil-bump? any/c)]
-  [hypernest-coil-bump-data (-> hypernest-coil-bump? any/c)]
-  [hypernest-coil-bump-bump-degree (-> hypernest-coil-bump? any/c)]
-  [hypernest-coil-bump-tails-hypernest
-    (-> hypernest-coil-bump? any/c)])
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-coil/c (-> dim-sys? flat-contract?)])
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-coil-bump?
+  hypernest-coil-bump-overall-degree
+  hypernest-coil-bump-data
+  hypernest-coil-bump-bump-degree
+  hypernest-coil-bump-tails-hypernest)
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-coil/c)
 (module+ private/hypernest #/provide
   hypernest-furl)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-get-coil
-    (->i ([hn hypernest?])
-      [_ (hn) (hypernest-coil/c #/hypernest-get-dim-sys hn)])])
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-get-coil)
 
 (module+ private/hypernest #/provide
   hnb-open)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hnb-open? (-> any/c boolean?)]
-  [hnb-open-degree (-> hnb-open? any/c)]
-  [hnb-open-data (-> hnb-open? any/c)])
+(module+ private/hypernest #/provide #/own-contract-out
+  hnb-open?
+  hnb-open-degree
+  hnb-open-data)
 (module+ private/hypernest #/provide
   hnb-labeled)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hnb-labeled? (-> any/c boolean?)]
-  [hnb-labeled-degree (-> hnb-labeled? any/c)]
-  [hnb-labeled-data (-> hnb-labeled? any/c)])
+(module+ private/hypernest #/provide #/own-contract-out
+  hnb-labeled?
+  hnb-labeled-degree
+  hnb-labeled-data)
 (module+ private/hypernest #/provide
   hnb-unlabeled)
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hnb-unlabeled? (-> any/c boolean?)]
-  [hnb-unlabeled-degree (-> hnb-unlabeled? any/c)])
-(module+ private/hypernest #/provide #/shim-contract-out
-  [hypernest-bracket? (-> any/c boolean?)]
-  [hypernest-bracket/c (-> contract? contract?)]
+(module+ private/hypernest #/provide #/own-contract-out
+  hnb-unlabeled?
+  hnb-unlabeled-degree)
+(module+ private/hypernest #/provide #/own-contract-out
+  hypernest-bracket?
+  hypernest-bracket/c
   ; TODO: Uncomment this export if we ever need it.
-;  [hypernest-bracket-degree (-> hypernest-bracket? any/c)]
-  [hypertee-bracket->hypernest-bracket
-    (-> hypertee-bracket? (or/c hnb-labeled? hnb-unlabeled?))]
-  [compatible-hypernest-bracket->hypertee-bracket
-    (-> (or/c hnb-labeled? hnb-unlabeled?) hypernest-bracket?)]
-  [hypernest-from-brackets
-    (->i
-      (
-        [ds dim-sys?]
-        [degree (ds) (dim-sys-dim/c ds)]
-        [brackets (ds)
-          (listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])
-      [_ (ds) (hypernest/c (hypertee-snippet-format-sys) ds)])]
-  [hn-bracs
-    (->i ([ds dim-sys?] [degree (ds) (dim-sys-dim/c ds)])
-      #:rest
-      [brackets (ds)
-        (w- dim/c (dim-sys-dim/c ds)
-        #/listof #/or/c (hypernest-bracket/c dim/c) dim/c)]
-      [_ (ds) (hypernest/c (hypertee-snippet-format-sys) ds)])]
-  [hypernest-get-brackets
-    (->i ([hn hypernest?])
-      [_ (hn)
-        (w- ds (hypernest-get-dim-sys hn)
-        #/listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])])
+;  hypernest-bracket-degree
+  hypertee-bracket->hypernest-bracket
+  compatible-hypernest-bracket->hypertee-bracket
+  hypernest-from-brackets
+  hn-bracs
+  hypernest-get-brackets)
 
 (module+ private/test #/provide
   snippet-sys-snippet-filter-maybe)
@@ -3842,7 +3759,8 @@
 
 ; TODO: Export this.
 ; TODO: Use the things that use this.
-(define (hypernest? v)
+(define/own-contract (hypernest? v)
+  (-> any/c boolean?)
   (or
     (hypernest-zero? v)
     (hypernest-nonzero? v)))
@@ -3909,7 +3827,8 @@
        ,sfs ,uds ,ob ,b-to-value/c ,h-to-value/c)))
 
 ; TODO: Use the things that use this.
-(define (hypernest/c sfs uds)
+(define/own-contract (hypernest/c sfs uds)
+  (-> snippet-format-sys? dim-sys? flat-contract?)
   (rename-contract
     (hypernestof-lazy/ob-c sfs uds (flat-obstinacy)
       (fn get-bump-interior-shape any/c)
@@ -3917,7 +3836,24 @@
     `(hypernest/c ,sfs ,uds)))
 
 ; TODO: Use the things that use this.
-(define (hypernestof/ob-c sfs uds ob b-to-value/c h-to-value/c)
+(define/own-contract
+  (hypernestof/ob-c sfs uds ob b-to-value/c h-to-value/c)
+  (->i
+    (
+      [sfs snippet-format-sys?]
+      [ds dim-sys?]
+      [ob obstinacy?]
+      [b-to-value/c (sfs ds ob)
+        (w- ffdstsss (snippet-format-sys-functor sfs)
+        #/w- ss (functor-sys-apply-to-object ffdstsss ds)
+        #/-> (snippet-sys-unlabeled-shape/c ss)
+          (obstinacy-contract/c ob))]
+      [h-to-value/c (sfs ds ob)
+        (w- ffdstsss (snippet-format-sys-functor sfs)
+        #/w- ss (functor-sys-apply-to-object ffdstsss ds)
+        #/-> (snippet-sys-unlabeled-shape/c ss)
+          (obstinacy-contract/c ob))])
+    [_ (ob) (obstinacy-contract/c ob)])
   (rename-contract
     (hypernestof-lazy/ob-c sfs uds ob
       (fn get-bump-interior-shape
@@ -3925,7 +3861,8 @@
       (fn get-hole #/h-to-value/c #/get-hole))
     `(hypernestof/ob-c ,sfs ,uds ,ob ,b-to-value/c ,h-to-value/c)))
 
-(define (hypernest-get-dim-sys hn)
+(define/own-contract (hypernest-get-dim-sys hn)
+  (-> hypernest? dim-sys?)
   (dlog 'zk1 hn
   #/mat hn (hypernest-zero-unchecked content)
     (hypertee-get-dim-sys content)
@@ -4211,6 +4148,11 @@
           extended-hvv-to-maybe-v)
       #/fn result-extended
         (hypernest-nonzero-unchecked d result-extended)))))
+(ascribe-own-contract hypernest-snippet-sys? (-> any/c boolean?))
+(ascribe-own-contract hypernest-snippet-sys-snippet-format-sys
+  (-> hypernest-snippet-sys? snippet-format-sys?))
+(ascribe-own-contract hypernest-snippet-sys-dim-sys
+  (-> hypernest-snippet-sys? dim-sys?))
 (define-match-expander-attenuated
   attenuated-hypernest-snippet-sys
   unguarded-hypernest-snippet-sys
@@ -4356,6 +4298,10 @@
       (dissectfn (hypernest-snippet-format-sys orig-sfs)
         (hypernest-functor-from-dim-sys-to-snippet-sys-sys
           orig-sfs)))))
+(ascribe-own-contract hypernest-snippet-format-sys?
+  (-> any/c boolean?))
+(ascribe-own-contract hypernest-snippet-format-sys-original
+  (-> hypernest-snippet-format-sys? snippet-format-sys?))
 (define-match-expander-attenuated
   attenuated-hypernest-snippet-format-sys
   unguarded-hypernest-snippet-format-sys
@@ -4395,7 +4341,13 @@
     (just shape)
     shape))
 
-(define (hypernest-get-hole-zero-maybe hn)
+(define/own-contract (hypernest-get-hole-zero-maybe hn)
+  (->
+    (and/c hypernest?
+      (by-own-method/c #:obstinacy (flat-obstinacy) hn
+        (hypernest/c (hypertee-snippet-format-sys)
+          (hypernest-get-dim-sys hn))))
+    maybe?)
   (4:dlog 'hqq-j1
   #/mat hn (hypernest-zero-unchecked content)
     (nothing)
@@ -4404,8 +4356,32 @@
     (4:dlog 'hqq-j3
     #/hypertee-get-hole-zero-maybe hn-extended)))
 
-(define
+(define/own-contract
   (hypernest-join-list-and-tail-along-0 ds past-snippets last-snippet)
+  (->i
+    (
+      [ds dim-sys?]
+      [past-snippets (ds last-snippet)
+        (w- ss
+          (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
+        #/w- shape-ss (snippet-sys-shape-snippet-sys ss)
+        #/listof #/and/c
+          (snippet-sys-snippet-with-degree=/c ss
+            (snippet-sys-snippet-degree ss last-snippet))
+          (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+            (if
+              (dim-sys-dim=0? ds
+                (snippet-sys-snippet-degree shape-ss hole))
+              trivial?
+              any/c)))]
+      [last-snippet (ds)
+        (w- ss
+          (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
+        #/snippet-sys-snippet-with-0<degree/c ss)])
+    [_ (ds last-snippet)
+      (w- ss (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
+      #/snippet-sys-snippet-with-degree=/c ss
+        (snippet-sys-snippet-degree ss last-snippet))])
   (w- sfs (hypernest-snippet-format-sys #/hypertee-snippet-format-sys)
   #/w- ffdstsss (snippet-format-sys-functor sfs)
   #/w- shape-zero
@@ -4433,6 +4409,7 @@
   (hypernest-coil-zero?)
   hypernest-coil-zero
   'hypernest-coil-zero (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypernest-coil-zero? (-> any/c boolean?))
 (define-imitation-simple-struct
   (hypernest-coil-hole?
     hypernest-coil-hole-overall-degree
@@ -4441,6 +4418,15 @@
     hypernest-coil-hole-tails-hypertee)
   hypernest-coil-hole
   'hypernest-coil-hole (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypernest-coil-hole? (-> any/c boolean?))
+(ascribe-own-contract hypernest-coil-hole-overall-degree
+  (-> hypernest-coil-hole? any/c))
+(ascribe-own-contract hypernest-coil-hole-hole
+  (-> hypernest-coil-hole? any/c))
+(ascribe-own-contract hypernest-coil-hole-data
+  (-> hypernest-coil-hole? any/c))
+(ascribe-own-contract hypernest-coil-hole-tails-hypertee
+  (-> hypernest-coil-hole? any/c))
 (define-imitation-simple-struct
   (hypernest-coil-bump?
     hypernest-coil-bump-overall-degree
@@ -4449,6 +4435,15 @@
     hypernest-coil-bump-tails-hypernest)
   hypernest-coil-bump
   'hypernest-coil-bump (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypernest-coil-bump? (-> any/c boolean?))
+(ascribe-own-contract hypernest-coil-bump-overall-degree
+  (-> hypernest-coil-bump? any/c))
+(ascribe-own-contract hypernest-coil-bump-data
+  (-> hypernest-coil-bump? any/c))
+(ascribe-own-contract hypernest-coil-bump-bump-degree
+  (-> hypernest-coil-bump? any/c))
+(ascribe-own-contract hypernest-coil-bump-tails-hypernest
+  (-> hypernest-coil-bump? any/c))
 
 ; NOTE DEBUGGABILITY: This is here for debugging. Unlike the
 ; unattenuated version, this one has an extra `ds` argument.
@@ -4483,7 +4478,8 @@
     [_ any/c])
   (hypernest-coil-hole overall-degree hole data tails-hypertee))
 
-(define (hypernest-coil/c ds)
+(define/own-contract (hypernest-coil/c ds)
+  (-> dim-sys? flat-contract?)
   (w- ss (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
   #/w- shape-ss (snippet-sys-shape-snippet-sys ss)
   #/rename-contract
@@ -4834,21 +4830,31 @@
   (hnb-open? hnb-open-degree hnb-open-data)
   hnb-open
   'hnb-open (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hnb-open? (-> any/c boolean?))
+(ascribe-own-contract hnb-open-degree (-> hnb-open? any/c))
+(ascribe-own-contract hnb-open-data (-> hnb-open? any/c))
 (define-imitation-simple-struct
   (hnb-labeled? hnb-labeled-degree hnb-labeled-data)
   hnb-labeled
   'hnb-labeled (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hnb-labeled? (-> any/c boolean?))
+(ascribe-own-contract hnb-labeled-degree (-> hnb-labeled? any/c))
+(ascribe-own-contract hnb-labeled-data (-> hnb-labeled? any/c))
 (define-imitation-simple-struct
   (hnb-unlabeled? hnb-unlabeled-degree)
   hnb-unlabeled
   'hnb-unlabeled (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hnb-unlabeled? (-> any/c boolean?))
+(ascribe-own-contract hnb-unlabeled-degree (-> hnb-unlabeled? any/c))
 
 ; TODO: Use this.
-(define (hypernest-bracket? v)
+(define/own-contract (hypernest-bracket? v)
+  (-> any/c boolean?)
   (or (hnb-open? v) (hnb-labeled? v) (hnb-unlabeled? v)))
 
 ; TODO: Use this.
-(define (hypernest-bracket/c dim/c)
+(define/own-contract (hypernest-bracket/c dim/c)
+  (-> contract? contract?)
   (w- dim/c (coerce-contract 'hypernest-bracket/c dim/c)
   #/rename-contract
     (or/c
@@ -4858,18 +4864,22 @@
     `(hypernest-bracket/c ,(contract-name dim/c))))
 
 ; TODO: Use this.
-(define (hypernest-bracket-degree bracket)
+(define/own-contract (hypernest-bracket-degree bracket)
+  (-> hypernest-bracket? any/c)
   (mat bracket (hnb-open d data) d
   #/mat bracket (hnb-labeled d data) d
   #/dissect bracket (hnb-unlabeled d) d))
 
 ; TODO: Use this.
-(define (hypertee-bracket->hypernest-bracket bracket)
+(define/own-contract (hypertee-bracket->hypernest-bracket bracket)
+  (-> hypertee-bracket? (or/c hnb-labeled? hnb-unlabeled?))
   (mat bracket (htb-labeled d data) (hnb-labeled d data)
   #/dissect bracket (htb-unlabeled d) (hnb-unlabeled d)))
 
 ; TODO: Use this.
-(define (compatible-hypernest-bracket->hypertee-bracket bracket)
+(define/own-contract
+  (compatible-hypernest-bracket->hypertee-bracket bracket)
+  (-> (or/c hnb-labeled? hnb-unlabeled?) hypernest-bracket?)
   (mat bracket (hnb-labeled d data) (htb-labeled d data)
   #/dissect bracket (hnb-unlabeled d) (htb-unlabeled d)))
 
@@ -5009,12 +5019,25 @@
     degree #t brackets))
 
 ; TODO: Use this.
-(define (hypernest-from-brackets ds degree brackets)
+(define/own-contract (hypernest-from-brackets ds degree brackets)
+  (->i
+    (
+      [ds dim-sys?]
+      [degree (ds) (dim-sys-dim/c ds)]
+      [brackets (ds)
+        (listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])
+    [_ (ds) (hypernest/c (hypertee-snippet-format-sys) ds)])
   (explicit-hypernest-from-brackets
     'hypernest-from-brackets (fn hnb hnb) ds degree brackets))
 
 ; TODO: Use this.
-(define (hn-bracs ds degree . brackets)
+(define/own-contract (hn-bracs ds degree . brackets)
+  (->i ([ds dim-sys?] [degree (ds) (dim-sys-dim/c ds)])
+    #:rest
+    [brackets (ds)
+      (w- dim/c (dim-sys-dim/c ds)
+      #/listof #/or/c (hypernest-bracket/c dim/c) dim/c)]
+    [_ (ds) (hypernest/c (hypertee-snippet-format-sys) ds)])
   (4:dlog 'hqq-d1
   #/explicit-hypernest-from-brackets 'hn-bracs (fn hnb hnb) ds degree
     (list-map brackets #/fn closing-bracket
@@ -5117,7 +5140,11 @@
         stack orig-d tails-hypernest)
     #/cons (hnb-open bump-degree data) recursive-result)))
 
-(define (hypernest-get-brackets hn)
+(define/own-contract (hypernest-get-brackets hn)
+  (->i ([hn hypernest?])
+    [_ (hn)
+      (w- ds (hypernest-get-dim-sys hn)
+      #/listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])
   (dlog 'zl1 hn
   #/w- ds (hypernest-get-dim-sys hn)
   #/w- hnss (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -160,7 +160,7 @@
   make-atomic-set-element-sys-impl-from-contract ok/c
   prop:atomic-set-element-sys)
 
-(require punctaffy/private/shim)
+(require lathe-morphisms/private/shim)
 
 (require #/only-in punctaffy/hypersnippet/dim
   dim-sys? dim-sys-category-sys dim-sys-category-sys? dim-sys-dim<?

--- a/punctaffy-lib/hypersnippet/snippet.rkt
+++ b/punctaffy-lib/hypersnippet/snippet.rkt
@@ -4,7 +4,7 @@
 ;
 ; An interface for data structures that are hypersnippet-shaped.
 
-;   Copyright 2019-2021 The Lathe Authors
+;   Copyright 2019-2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -160,6 +160,9 @@
   make-atomic-set-element-sys-impl-from-contract ok/c
   prop:atomic-set-element-sys)
 
+; TODO NOW: Remove uses of `lathe-morphisms/private/shim`,
+; particularly including `shim-contract-out` and
+; `shim-recontract-out`.
 (require lathe-morphisms/private/shim)
 
 (require #/only-in punctaffy/hypersnippet/dim

--- a/punctaffy-lib/info.rkt
+++ b/punctaffy-lib/info.rkt
@@ -6,5 +6,6 @@
   (list
     "base"
     "lathe-comforts-lib"
-    "lathe-morphisms-lib"))
+    "lathe-morphisms-lib"
+    "reprovide-lang-lib"))
 (define build-deps (list "parendown-lib"))

--- a/punctaffy-lib/private/codebasewide-requires.rkt
+++ b/punctaffy-lib/private/codebasewide-requires.rkt
@@ -1,0 +1,23 @@
+#lang parendown/slash reprovide
+
+; codebasewide-requires.rkt
+;
+; An import list that's useful primarily for this codebase.
+
+;   Copyright 2022 The Lathe Authors
+;
+;   Licensed under the Apache License, Version 2.0 (the "License");
+;   you may not use this file except in compliance with the License.
+;   You may obtain a copy of the License at
+;
+;       http://www.apache.org/licenses/LICENSE-2.0
+;
+;   Unless required by applicable law or agreed to in writing,
+;   software distributed under the License is distributed on an
+;   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+;   either express or implied. See the License for the specific
+;   language governing permissions and limitations under the License.
+
+
+(only-in lathe-comforts/own-contract
+  ascribe-own-contract define/own-contract own-contract-out)

--- a/punctaffy-lib/private/experimental/hyprid.rkt
+++ b/punctaffy-lib/private/experimental/hyprid.rkt
@@ -6,7 +6,7 @@
 ; hypersnippet-shaped data using "stripes" of low-dimensional
 ; hypertees.
 
-;   Copyright 2017-2019, 2021 The Lathe Authors
+;   Copyright 2017-2019, 2021-2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@
 (require #/only-in racket/contract/base -> ->i any any/c)
 (require #/only-in racket/contract/combinator
   contract-first-order-passes?)
-(require #/only-in racket/contract/region define/contract)
 (require #/only-in racket/math natural?)
 
 (require #/only-in lathe-comforts
@@ -35,6 +34,9 @@
 (require #/only-in lathe-comforts/struct struct-easy)
 (require #/only-in lathe-comforts/trivial trivial)
 (require #/only-in lathe-morphisms/in-fp/mediary/set ok/c)
+
+(require punctaffy/private/shim)
+(init-shim)
 
 (require #/only-in punctaffy/hypersnippet/dim
   dim-successors-sys? dim-successors-sys-dim-sys
@@ -50,14 +52,17 @@
   hypertee-get-brackets hypertee-increase-degree-to
   hypertee-map-highest-degree hypertee-v-map-highest-degree)
 
+
 (provide
   ; TODO: See if there's anything more abstract we can export in place
   ; of these structure types.
   (struct-out hyprid)
   (struct-out island-cane)
   (struct-out lake-cane)
-  (struct-out non-lake-cane)
-  hyprid-destripe-once hyprid-fully-destripe
+  (struct-out non-lake-cane))
+(provide #/own-contract-out
+  hyprid-destripe-once
+  hyprid-fully-destripe
   hyprid-stripe-once)
 
 
@@ -115,7 +120,7 @@
       #/unless (= pred-striped-degrees striped-degrees-2)
         (error "Expected striped-hypertee to be an island-cane of striped-degrees one less")))))
 
-(define/contract (hyprid-degree h)
+(define/own-contract (hyprid-degree h)
   (->i ([h hyprid?])
     [_ (h)
       (dim-sys-dim/c #/dim-successors-sys-dim-sys
@@ -187,7 +192,7 @@
 
 (struct-easy (non-lake-cane data) #:equal)
 
-(define/contract (hyprid-map-lakes-highest-degree h func)
+(define/own-contract (hyprid-map-lakes-highest-degree h func)
   (-> hyprid? (-> hypertee? any/c any/c) hyprid?)
   (dissect h
     (hyprid dss unstriped-degrees striped-degrees striped-hypertee)
@@ -213,7 +218,7 @@
     #/mat rest (non-lake-cane data) (non-lake-cane data)
     #/error "Internal error")))
 
-(define/contract (hyprid-destripe-once h)
+(define/own-contract (hyprid-destripe-once h)
   (-> hyprid? hyprid?)
   (dissect h
     (hyprid dss unstriped-degrees striped-degrees striped-hypertee)
@@ -259,14 +264,14 @@
     #/mat rest (non-lake-cane data) (non-lake-cane data)
     #/error "Internal error")))
 
-(define/contract (hyprid-fully-destripe h)
+(define/own-contract (hyprid-fully-destripe h)
   (-> hyprid? hypertee?)
   (dissect h
     (hyprid dss unstriped-degrees striped-degrees striped-hypertee)
   #/mat striped-degrees 0 striped-hypertee
   #/hyprid-fully-destripe #/hyprid-destripe-once h))
 
-(define/contract (hyprid-dv-each-lake-all-degrees h body)
+(define/own-contract (hyprid-dv-each-lake-all-degrees h body)
   (->i
     (
       [h hyprid?]
@@ -287,7 +292,7 @@
 ;
 ; TODO: Test this.
 ;
-(define/contract (hyprid-stripe-once h)
+(define/own-contract (hyprid-stripe-once h)
   (-> hyprid? hyprid?)
   
   (define (location-needs-state? location)

--- a/punctaffy-lib/private/experimental/macro/hypernest-macro.rkt
+++ b/punctaffy-lib/private/experimental/macro/hypernest-macro.rkt
@@ -4,7 +4,7 @@
 ;
 ; A framework for macros which take hypersnippet-shaped syntax.
 
-;   Copyright 2018-2019, 2021 The Lathe Authors
+;   Copyright 2018-2019, 2021-2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -50,9 +50,8 @@
   (require 'private/lathe-debugging/placebo))
 
 (require #/only-in racket/contract/base
-  -> ->i and/c any/c contract-out flat-contract? list/c listof none/c
-  or/c rename-contract)
-(require #/only-in racket/contract/region define/contract)
+  -> ->i and/c any/c flat-contract? list/c listof none/c or/c
+  rename-contract)
 (require #/only-in racket/math natural?)
 (require #/only-in syntax/parse
   exact-positive-integer id syntax-parse)
@@ -69,6 +68,9 @@
   auto-equal auto-write define-imitation-simple-generics
   define-imitation-simple-struct)
 (require #/only-in lathe-comforts/trivial trivial trivial?)
+
+(require punctaffy/private/shim)
+(init-shim)
 
 (require #/only-in punctaffy/hyperbracket
   hyperbracket-close-with-degree hyperbracket-notation?
@@ -104,102 +106,54 @@
 
 (provide
   hn-tag-0-s-expr-stx)
-(provide #/contract-out
-  [hn-tag-0-s-expr-stx? (-> any/c boolean?)]
-  [hn-tag-0-s-expr-stx-stx (-> hn-tag-0-s-expr-stx? syntax?)])
+(provide #/own-contract-out
+  hn-tag-0-s-expr-stx?
+  hn-tag-0-s-expr-stx-stx)
 (provide
   hn-tag-1-box)
-(provide #/contract-out
-  [hn-tag-1-box? (-> any/c boolean?)]
-  [hn-tag-1-box-stx-example (-> hn-tag-1-box? syntax?)])
+(provide #/own-contract-out
+  hn-tag-1-box?
+  hn-tag-1-box-stx-example)
 (provide
   hn-tag-1-list)
-(provide #/contract-out
-  [hn-tag-1-list? (-> any/c boolean?)]
-  [hn-tag-1-list-stx-example (-> hn-tag-1-list? syntax?)])
+(provide #/own-contract-out
+  hn-tag-1-list?
+  hn-tag-1-list-stx-example)
 (provide
   hn-tag-1-vector)
-(provide #/contract-out
-  [hn-tag-1-vector? (-> any/c boolean?)]
-  [hn-tag-1-vector-stx-example (-> hn-tag-1-vector? syntax?)])
+(provide #/own-contract-out
+  hn-tag-1-vector?
+  hn-tag-1-vector-stx-example)
 (provide
   hn-tag-1-prefab)
-(provide #/contract-out
-  [hn-tag-1-prefab? (-> any/c boolean?)]
-  [hn-tag-1-prefab-key (-> hn-tag-1-prefab? prefab-key?)]
-  [hn-tag-1-prefab-stx-example (-> hn-tag-1-prefab? syntax?)])
+(provide #/own-contract-out
+  hn-tag-1-prefab?
+  hn-tag-1-prefab-key
+  hn-tag-1-prefab-stx-example)
 (provide
   hn-tag-2-list*)
-(provide #/contract-out
-  [hn-tag-2-list*? (-> any/c boolean?)]
-  [hn-tag-2-list*-stx-example (-> hn-tag-2-list*? syntax?)])
+(provide #/own-contract-out
+  hn-tag-2-list*?
+  hn-tag-2-list*-stx-example)
 (provide
   hn-tag-unmatched-closing-bracket)
-(provide #/contract-out
-  [hn-tag-unmatched-closing-bracket? (-> any/c boolean?)])
+(provide #/own-contract-out
+  hn-tag-unmatched-closing-bracket?)
 (provide
   hn-tag-nest)
-(provide #/contract-out
-  [hn-tag-nest? (-> any/c boolean?)])
+(provide #/own-contract-out
+  hn-tag-nest?)
 (provide
   hn-tag-other)
-(provide #/contract-out
-  [hn-tag-other? (-> any/c boolean?)]
-  [hn-tag-other-val (-> hn-tag-other? any/c)]
-  
-  ; TODO: We should constrain this contract more. It should be
-  ;
-  ; (->i
-  ;   (
-  ;     [bump-degree (dim-sys-dim/c en-ds)]
-  ;     [tag any/c]
-  ;     [tails (bump-degree)
-  ;       (w- ss (hypernest-snippet-sys en-sfs en-ds)
-  ;       #/w- shape-ss (snippet-sys-shape-snippet-sys ss)
-  ;       #/and/c (snippet-sys-snippetof/c ss)
-  ;       #/by-own-method/c #:obstinacy (flat-obstinacy) tails
-  ;       #/w- d (snippet-sys-snippet-degree ss tails)
-  ;       #/w- has-d/c (snippet-sys-snippet-with-degree/c ss d)
-  ;       #/snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-  ;         (if
-  ;           (dim-sys-dim<? en-ds
-  ;             (snippet-sys-snippet-degree shape-ss hole)
-  ;             bump-degree)
-  ;           (and/c
-  ;             has-d/c
-  ;             (snippet-sys-snippet-fitting-shape/c ss hole))
-  ;           any/c))]
-  ;   [_ (bump-degree tails)
-  ;     (w- ss (hypernest-snippet-sys en-sfs en-ds)
-  ;     #/w- shape-ss (snippet-sys-shape-snippet-sys ss)
-  ;     #/w- d (snippet-sys-snippet-degree ss tails)
-  ;     #/w- has-d/c (snippet-sys-snippet-with-degree/c ss d)
-  ;     #/w- exprlike/c
-  ;       (and/c has-d/c
-  ;         (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
-  ;           (if
-  ;             (dim-sys-dim=0? en-ds
-  ;               (snippet-sys-snippet-degree shape-ss hole))
-  ;             trivial?
-  ;             any/c)))
-  ;     #/maybe/c #/list/c syntax?
-  ;       (and/c exprlike/c exprlike/c has-d/c))])
-  ;
-  ; In order for this to make complete sense as a contract, we should
-  ; probably be exporting `en-sfs` and `en-ds`. We might want to
-  ; export the derived `ss` and `shape-ss` as well.
-  ;
-  [parse-list*-tag
-    (-> any/c any/c any/c
-      (maybe/c #/list/c syntax? any/c any/c any/c))]
-  
-  [hn-expr/c (-> flat-contract?)]
-  [unlabeled-hn-expr-with-degree-1/c (-> flat-contract?)]
-  [s-expr-stx->hn-expr
-    (-> syntax? syntax? #/unlabeled-hn-expr-with-degree-1/c)]
-  [hn-expr-forget-nests (-> (hn-expr/c) #/hn-expr/c)]
-  [hn-expr->s-expr-stx-list
-    (-> (unlabeled-hn-expr-with-degree-1/c) #/listof syntax?)])
+(provide #/own-contract-out
+  hn-tag-other?
+  hn-tag-other-val
+  parse-list*-tag
+  hn-expr/c
+  unlabeled-hn-expr-with-degree-1/c
+  s-expr-stx->hn-expr
+  hn-expr-forget-nests
+  hn-expr->s-expr-stx-list)
 
 
 ; NOTE DEBUGGABILITY: These are here for debugging.
@@ -211,13 +165,13 @@
     (require punctaffy/hypersnippet/hypernest)
     (require punctaffy/hypersnippet/hypertee)
     (require punctaffy/hypersnippet/snippet)
-    (define/contract (verify-ht ht)
+    (define/own-contract (verify-ht ht)
       (->
         (and/c hypertee?
           (by-own-method/c ht #/hypertee/c #/hypertee-get-dim-sys ht))
         any/c)
       ht)
-    (define/contract (verify-hn hn)
+    (define/own-contract (verify-hn hn)
       (->
         (and/c hypernest?
           (by-own-method/c hn
@@ -344,7 +298,7 @@
   #/w- prop stx-example
   #/datum->syntax ctxt datum srcloc prop))
 
-(define/contract (syntax-local-maybe identifier)
+(define/own-contract (syntax-local-maybe identifier)
   (-> any/c maybe?)
   (if (identifier? identifier)
     (w- dummy (box #/trivial)
@@ -436,6 +390,9 @@
   (hn-tag-0-s-expr-stx? hn-tag-0-s-expr-stx-stx)
   unguarded-hn-tag-0-s-expr-stx
   'hn-tag-0-s-expr-stx (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hn-tag-0-s-expr-stx? (-> any/c boolean?))
+(ascribe-own-contract hn-tag-0-s-expr-stx-stx
+  (-> hn-tag-0-s-expr-stx? syntax?))
 (define-match-expander-attenuated
   attenuated-hn-tag-0-s-expr-stx
   unguarded-hn-tag-0-s-expr-stx
@@ -450,6 +407,9 @@
   (hn-tag-1-box? hn-tag-1-box-stx-example)
   unguarded-hn-tag-1-box
   'hn-tag-1-box (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hn-tag-1-box? (-> any/c boolean?))
+(ascribe-own-contract hn-tag-1-box-stx-example
+  (-> hn-tag-1-box? syntax?))
 (define-match-expander-attenuated
   attenuated-hn-tag-1-box
   unguarded-hn-tag-1-box
@@ -464,6 +424,9 @@
   (hn-tag-1-list? hn-tag-1-list-stx-example)
   unguarded-hn-tag-1-list
   'hn-tag-1-list (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hn-tag-1-list? (-> any/c boolean?))
+(ascribe-own-contract hn-tag-1-list-stx-example
+  (-> hn-tag-1-list? syntax?))
 (define-match-expander-attenuated
   attenuated-hn-tag-1-list
   unguarded-hn-tag-1-list
@@ -478,6 +441,9 @@
   (hn-tag-1-vector? hn-tag-1-vector-stx-example)
   unguarded-hn-tag-1-vector
   'hn-tag-1-vector (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hn-tag-1-vector? (-> any/c boolean?))
+(ascribe-own-contract hn-tag-1-vector-stx-example
+  (-> hn-tag-1-vector? syntax?))
 (define-match-expander-attenuated
   attenuated-hn-tag-1-vector
   unguarded-hn-tag-1-vector
@@ -492,6 +458,11 @@
   (hn-tag-1-prefab? hn-tag-1-prefab-key hn-tag-1-prefab-stx-example)
   unguarded-hn-tag-1-prefab
   'hn-tag-1-prefab (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hn-tag-1-prefab? (-> any/c boolean?))
+(ascribe-own-contract hn-tag-1-prefab-key
+  (-> hn-tag-1-prefab? prefab-key?))
+(ascribe-own-contract hn-tag-1-prefab-stx-example
+  (-> hn-tag-1-prefab? syntax?))
 (define-match-expander-attenuated
   attenuated-hn-tag-1-prefab
   unguarded-hn-tag-1-prefab
@@ -507,6 +478,9 @@
   (hn-tag-2-list*? hn-tag-2-list*-stx-example)
   unguarded-hn-tag-2-list*
   'hn-tag-2-list* (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hn-tag-2-list*? (-> any/c boolean?))
+(ascribe-own-contract hn-tag-2-list*-stx-example
+  (-> hn-tag-2-list*? syntax?))
 (define-match-expander-attenuated
   attenuated-hn-tag-2-list*
   unguarded-hn-tag-2-list*
@@ -539,6 +513,8 @@
   'hn-tag-unmatched-closing-bracket (current-inspector)
   (auto-write)
   (auto-equal))
+(ascribe-own-contract hn-tag-unmatched-closing-bracket?
+  (-> any/c boolean?))
 
 ; The `hn-tag-nest` tag can occur as a bump of degree infinity
 ; (in the sense of `(extended-with-top-dim-infinite)` in the system
@@ -560,6 +536,7 @@
   (hn-tag-nest?)
   hn-tag-nest
   'hn-tag-nest (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hn-tag-nest? (-> any/c boolean?))
 
 ; This is a value designated to let hn-expression users put custom
 ; kinds of data into an hn-expression. It can occur as a bump or a
@@ -568,6 +545,8 @@
   (hn-tag-other? hn-tag-other-val)
   hn-tag-other
   'hn-tag-other (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hn-tag-other? (-> any/c boolean?))
+(ascribe-own-contract hn-tag-other-val (-> hn-tag-other? any/c))
 
 (define example-list*-shape
   (w- ds en-ds
@@ -593,7 +572,54 @@
       #/dissect example-data (trivial)
       #/just #/trivial))))
 
-(define (parse-list*-tag bump-degree tag tails)
+(define/own-contract (parse-list*-tag bump-degree tag tails)
+  
+  ; TODO SPECIFIC: We should constrain this contract more. It should
+  ; be
+  ;
+  ; (->i
+  ;   (
+  ;     [bump-degree (dim-sys-dim/c en-ds)]
+  ;     [tag any/c]
+  ;     [tails (bump-degree)
+  ;       (w- ss (hypernest-snippet-sys en-sfs en-ds)
+  ;       #/w- shape-ss (snippet-sys-shape-snippet-sys ss)
+  ;       #/and/c (snippet-sys-snippetof/c ss)
+  ;       #/by-own-method/c #:obstinacy (flat-obstinacy) tails
+  ;       #/w- d (snippet-sys-snippet-degree ss tails)
+  ;       #/w- has-d/c (snippet-sys-snippet-with-degree/c ss d)
+  ;       #/snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+  ;         (if
+  ;           (dim-sys-dim<? en-ds
+  ;             (snippet-sys-snippet-degree shape-ss hole)
+  ;             bump-degree)
+  ;           (and/c
+  ;             has-d/c
+  ;             (snippet-sys-snippet-fitting-shape/c ss hole))
+  ;           any/c))]
+  ;   [_ (bump-degree tails)
+  ;     (w- ss (hypernest-snippet-sys en-sfs en-ds)
+  ;     #/w- shape-ss (snippet-sys-shape-snippet-sys ss)
+  ;     #/w- d (snippet-sys-snippet-degree ss tails)
+  ;     #/w- has-d/c (snippet-sys-snippet-with-degree/c ss d)
+  ;     #/w- exprlike/c
+  ;       (and/c has-d/c
+  ;         (snippet-sys-snippetof/ob-c ss (flat-obstinacy) #/fn hole
+  ;           (if
+  ;             (dim-sys-dim=0? en-ds
+  ;               (snippet-sys-snippet-degree shape-ss hole))
+  ;             trivial?
+  ;             any/c)))
+  ;     #/maybe/c #/list/c syntax?
+  ;       (and/c exprlike/c exprlike/c has-d/c))])
+  ;
+  ; In order for this to make complete sense as a contract, we should
+  ; probably be exporting `en-sfs` and `en-ds`. We might want to
+  ; export the derived `ss` and `shape-ss` as well.
+  ;
+  (-> any/c any/c any/c
+    (maybe/c #/list/c syntax? any/c any/c any/c))
+  
   (w- ds en-ds
   #/w- ss (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
   #/w- n-d en-n-d
@@ -633,7 +659,8 @@
   
   #/just #/list stx-example list*-elems list*-tail tail))
 
-(define (hn-expr/c)
+(define/own-contract (hn-expr/c)
+  (-> flat-contract?)
   (w- ds en-ds
   #/w- n-d en-n-d
   #/w- sfs (hypertee-snippet-format-sys)
@@ -679,7 +706,8 @@
       (fn hole any/c))
     '(hn-expr/c)))
 
-(define (unlabeled-hn-expr-with-degree-1/c)
+(define/own-contract (unlabeled-hn-expr-with-degree-1/c)
+  (-> flat-contract?)
   (w- ds en-ds
   #/w- n-d en-n-d
   #/w- sfs (hypertee-snippet-format-sys)
@@ -707,7 +735,8 @@
 ; represent the other atoms, proper lists, improper lists, vectors,
 ; and prefab structs it encounters.
 ;
-(define (s-expr-stx->hn-expr err-dsl-stx stx)
+(define/own-contract (s-expr-stx->hn-expr err-dsl-stx stx)
+  (-> syntax? syntax? #/unlabeled-hn-expr-with-degree-1/c)
   (dlog 'hqq-b1
   #/w- ds en-ds
   #/w- n-d en-n-d
@@ -898,7 +927,7 @@
 ; reminder that hn-expressions aren't quite "expressions" so much as
 ; snippets of expression-like data.
 ;
-(define/contract (splicing-s-expr-stx->hn-expr err-dsl-stx stx)
+(define/own-contract (splicing-s-expr-stx->hn-expr err-dsl-stx stx)
   (-> syntax? syntax? #/hn-expr/c)
   (w- ds en-ds
   #/w- n-d en-n-d
@@ -920,7 +949,8 @@
 ; structure we use... unless the data structure we use is made of
 ; cons-cell-based Racket syntax objects.
 ;
-(define (hn-expr-forget-nests hn)
+(define/own-contract (hn-expr-forget-nests hn)
+  (-> (hn-expr/c) #/hn-expr/c)
   (dlog 'hqq-l1
   #/w- ds en-ds
   #/w- ss (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
@@ -963,7 +993,8 @@
 
 ; This converts an hn-expression back into a list of syntax objects,
 ; as long as it doesn't have any `hn-tag-nest` bumps.
-(define (hn-expr->s-expr-stx-list hn)
+(define/own-contract (hn-expr->s-expr-stx-list hn)
+  (-> (unlabeled-hn-expr-with-degree-1/c) #/listof syntax?)
   (w- ds en-ds
   #/w- ss (hypernest-snippet-sys (hypertee-snippet-format-sys) ds)
   #/w- shape-ss (snippet-sys-shape-snippet-sys ss)

--- a/punctaffy-lib/private/experimental/monad.rkt
+++ b/punctaffy-lib/private/experimental/monad.rkt
@@ -7,7 +7,7 @@
 ; straightforward to define dictiaonries that are comparable by
 ; `equal?`.
 
-;   Copyright 2017-2019 The Lathe Authors
+;   Copyright 2017-2019, 2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -23,13 +23,17 @@
 
 
 (require #/only-in racket/contract/base -> any any/c cons/c)
-(require #/only-in racket/contract/region define/contract)
 (require #/only-in racket/generic define-generics)
 
 (require #/only-in lathe-comforts dissect expect)
 (require #/only-in lathe-comforts/struct struct-easy)
 
-(require #/only-in "monoid.rkt" monoid-empty monoid-append)
+(require punctaffy/private/shim)
+(init-shim)
+
+(require #/only-in punctaffy/private/experimental/monoid
+  monoid-empty monoid-append)
+
 
 (provide gen:monad monad? monad/c
   monad-done monad-bind monad-map monad-join)
@@ -61,13 +65,13 @@
         (error "Expected this to be a monad-identity")
         leaf))
     
-    (define/contract (monad-bind this prefix leaf-to-suffix)
+    (define/own-contract (monad-bind this prefix leaf-to-suffix)
       (-> any/c any/c (-> any/c any) any)
       (expect this (monad-identity)
         (error "Expected this to be a monad-identity")
       #/leaf-to-suffix prefix))
     
-    (define/contract (monad-map this tree leaf-to-leaf)
+    (define/own-contract (monad-map this tree leaf-to-leaf)
       (-> any/c any/c (-> any/c any) any)
       (expect this (monad-identity)
         (error "Expected this to be a monad-identity")
@@ -96,7 +100,7 @@
         (error "Expected this to be a monad-from-monoid")
       #/cons (monoid-empty monoid) leaf))
     
-    (define/contract (monad-bind this prefix leaf-to-suffix)
+    (define/own-contract (monad-bind this prefix leaf-to-suffix)
       (-> any/c (cons/c any/c any/c) (-> any/c #/cons/c any/c any/c)
         any)
       (expect this (monad-from-monoid monoid)
@@ -105,7 +109,7 @@
       #/dissect (leaf-to-suffix leaf) (cons suffix leaf)
       #/cons (monoid-append monoid prefix suffix) leaf))
     
-    (define/contract (monad-map this tree leaf-to-leaf)
+    (define/own-contract (monad-map this tree leaf-to-leaf)
       (-> any/c (cons/c any/c any/c) (-> any/c any/c) any)
       (expect this (monad-from-monoid monoid)
         (error "Expected this to be a monad-from-monoid")

--- a/punctaffy-lib/private/experimental/monoid.rkt
+++ b/punctaffy-lib/private/experimental/monoid.rkt
@@ -7,7 +7,7 @@
 ; straightforward to define dictiaonries that are comparable by
 ; `equal?`.
 
-;   Copyright 2017-2018 The Lathe Authors
+;   Copyright 2017-2018, 2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -23,11 +23,14 @@
 
 
 (require #/only-in racket/contract/base -> any any/c)
-(require #/only-in racket/contract/region define/contract)
 (require #/only-in racket/generic define-generics)
 
 (require #/only-in lathe-comforts expect)
 (require #/only-in lathe-comforts/struct struct-easy)
+
+(require punctaffy/private/shim)
+(init-shim)
+
 
 (provide gen:monoid monoid? monoid/c monoid-empty monoid-append)
 
@@ -54,7 +57,7 @@
         (error "Expected this to be a monoid-trivial")
         null))
     
-    (define/contract (monoid-append this prefix suffix)
+    (define/own-contract (monoid-append this prefix suffix)
       (-> any/c null? null? any)
       (expect this (monoid-trivial)
         (error "Expected this to be a monoid-trivial")

--- a/punctaffy-lib/private/hypernest-as-ast.rkt
+++ b/punctaffy-lib/private/hypernest-as-ast.rkt
@@ -311,10 +311,20 @@
   ; called `hypernest-join-selective`, and it would use a much more
   ; specific contract.
   [hypernest-join-all-degrees-selective (-> hypernest? hypernest?)]
-  ; TODO PARITY: Continue looking for things to bring into parity from
-  ; here.
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys` and
+  ; `snippet-sys-snippet-map`. If it did exist, it would be called
+  ; `hypernest-map`, and it would use a much more specific contract.
   [hypernest-map-all-degrees
     (-> hypernest? (-> hypertee? any/c any/c) hypernest?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys` and
+  ; `snippet-sys-snippet-done`. If it did exist, it would pass the
+  ; hole shape argument before the data argument, and it would use a
+  ; more specific contract that asserted the result was of the
+  ; requested degree.
   [hypernest-done
     (->i
       (
@@ -326,9 +336,21 @@
   ; `punctaffy/hypersnippet/hypernest`, where it's called
   ; `hypernest-get-hole-zero-maybe` and has a more specific contract.
   [hypernest-get-hole-zero (-> hypernest? maybe?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys` and
+  ; `snippet-sys-snippet-join`. If it did exist, it would be called
+  ; `hypernest-join`, and it would use a much more specific contract.
   [hypernest-join-all-degrees
     (->i ([hn hypernest?])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypernest-snippet-sys` and `snippet-sys-snippet-bind`. If it did
+  ; exist, it would be called `hypernest-bind`, it would pass its
+  ; callback a hole shape rather than merely a degree, and it would
+  ; use a much more specific contract.
   [hypernest-dv-bind-all-degrees
     (->i
       (
@@ -337,6 +359,11 @@
           (w- ds (hypernest-dim-sys hn)
           #/-> (dim-sys-dim/c ds) any/c (hypernest/c ds))])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys` and
+  ; `snippet-sys-snippet-bind`. If it did exist, it would be called
+  ; `hypernest-bind`, and it would use a much more specific contract.
   [hypernest-bind-all-degrees
     (->i
       (
@@ -345,6 +372,13 @@
           (w- ds (hypernest-dim-sys hn)
           #/-> (hypertee/c ds) any/c (hypernest/c ds))])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys`,
+  ; `snippet-sys-snippet-select-if-degree`, and
+  ; `snippet-sys-snippet-bind-selective`. If it did exist, it would be
+  ; called `hypernest-bind-if-degree=`, and it would use a much more
+  ; specific contract.
   [hypernest-bind-one-degree
     (->i
       (
@@ -354,12 +388,26 @@
           (w- ds (hypernest-dim-sys hn)
           #/-> (hypertee/c ds) any/c (hypernest/c ds))])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys`,
+  ; `snippet-sys-snippet-select-if-degree`, and
+  ; `snippet-sys-snippet-join-selective`. If it did exist, it would be
+  ; called `hypernest-join-if-degree=`, and it would use a much more
+  ; specific contract.
   [hypernest-join-one-degree
     (->i
       (
         [degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
         [hn hypernest?])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypernest-snippet-sys`, `snippet-sys-snippet-bind`, and
+  ; `snippet-sys-snippet-set-degree-maybe`. If it did exist, it might
+  ; be called `hypernest-set-degree-and-bind`, and it would use a much
+  ; more specific contract.
   [hypernest-set-degree-and-bind-highest-degrees
     (->i
       (
@@ -369,6 +417,13 @@
           (w- ds (hypernest-dim-sys hn)
           #/-> (hypertee/c ds) any/c (hypernest/c ds))])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypernest-snippet-sys`, `snippet-sys-snippet-join`, and
+  ; `snippet-sys-snippet-set-degree-maybe`. If it did exist, it might
+  ; be called `hypernest-set-degree-and-join`, and it would use a much
+  ; more specific contract.
   [hypernest-set-degree-and-join-all-degrees
     (->i
       (
@@ -390,6 +445,9 @@
         [degree (ds) (dim-sys-0<dim/c ds)]
         [hns (ds) (listof #/hypernest/c ds)])
       [_ (ds) (hypernest/c ds)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't have as
+  ; strict a result contract and it has a match expander.
   [hypernest-furl
     (->i ([ds dim-sys?] [coil (ds) (hypernest-coil/c ds)])
       [_ (ds) (hypernest/c ds)])])

--- a/punctaffy-lib/private/hypernest-as-ast.rkt
+++ b/punctaffy-lib/private/hypernest-as-ast.rkt
@@ -272,8 +272,15 @@
         [func (hn)
           (-> (dim-sys-dim/c #/hypernest-dim-sys hn) any/c any/c)])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
-  ; TODO PARITY: Continue looking for things to bring into parity from
-  ; here.
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypernest-snippet-sys`, `snippet-sys-snippet-select-if-degree`,
+  ; and `snippet-sys-snippet-map-selective`. If it did exist, it would
+  ; be called `hypernest-map-if-degree=`, it would pass its callback a
+  ; hole shape in addition to the value, and it would use a more
+  ; specific contract that asserted the result was of the same degree
+  ; as the original.
   [hypernest-v-map-one-degree
     (->i
       (
@@ -282,18 +289,30 @@
         [func (-> any/c any/c)])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])])
 (provide
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/snippet`, where it's called `selected`.
   hypernest-join-selective-interpolation)
 (provide #/contract-out
   [hypernest-join-selective-interpolation? (-> any/c boolean?)]
   [hypernest-join-selective-interpolation-val
     (-> hypernest-join-selective-interpolation? any/c)])
 (provide
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/snippet`, where it's called `unselected`.
   hypernest-join-selective-non-interpolation)
 (provide #/contract-out
   [hypernest-join-selective-non-interpolation? (-> any/c boolean?)]
   [hypernest-join-selective-non-interpolation-val
     (-> hypernest-join-selective-interpolation? any/c)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys` and
+  ; `snippet-sys-snippet-join-selective`. If it did exist, it would be
+  ; called `hypernest-join-selective`, and it would use a much more
+  ; specific contract.
   [hypernest-join-all-degrees-selective (-> hypernest? hypernest?)]
+  ; TODO PARITY: Continue looking for things to bring into parity from
+  ; here.
   [hypernest-map-all-degrees
     (-> hypernest? (-> hypertee? any/c any/c) hypernest?)]
   [hypernest-done

--- a/punctaffy-lib/private/hypernest-as-ast.rkt
+++ b/punctaffy-lib/private/hypernest-as-ast.rkt
@@ -21,8 +21,8 @@
 
 
 (require #/only-in racket/contract/base
-  -> ->i and/c any any/c contract? contract-name contract-out list/c
-  listof not/c or/c rename-contract)
+  -> ->i and/c any any/c contract? contract-name contract-out
+  flat-contract? list/c listof not/c or/c rename-contract)
 (require #/only-in racket/contract/combinator coerce-contract)
 (require #/only-in racket/math natural?)
 (require #/only-in racket/struct make-constructor-style-printer)
@@ -92,6 +92,9 @@
 (provide
   hypernest-coil-hole)
 (provide #/contract-out
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where there's an extra
+  ; `hypernest-coil-hole-hole` field.
   [hypernest-coil-hole? (-> any/c boolean?)]
   [hypernest-coil-hole-overall-degree (-> hypernest-coil-hole? any/c)]
   [hypernest-coil-hole-data (-> hypernest-coil-hole? any/c)]
@@ -106,15 +109,37 @@
   [hypernest-coil-bump-bump-degree (-> hypernest-coil-bump? any/c)]
   [hypernest-coil-bump-tails-hypernest
     (-> hypernest-coil-bump? any/c)]
-  [hypernest-bracket-degree (-> (hypernest-bracket/c any/c) any/c)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it's not exported.
+  [hypernest-bracket-degree (-> hypernest-bracket? any/c)]
   [hypernest? (-> any/c boolean?)]
+  ; TODO PARITY: Bring `hypernest-dim-sys` into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it's called
+  ; `hypernest-get-dim-sys` and it's exported.
+  ; TODO PARITY: Bring `hypernest-coil` into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it's called
+  ; `hypernest-get-coil` and it's exported.
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it takes an extra `ds`
+  ; argument and it's not exported.
   [hypernest-degree
     (->i ([hn hypernest?])
       [_ (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it takes an extra `sfs`
+  ; argument. (Actually, `punctaffy/hypersnippet/hypernest`'s
+  ; implementation of hypernests might be a straightforward successor
+  ; of this one.)
   ; TODO DOCS: Consider more expressive hypernest contract combinators
   ; than `hypernest/c`, and come up with a new name for it.
-  [hypernest/c (-> dim-sys? contract?)]
-  [hypernest-coil/c (-> dim-sys? contract?)]
+  [hypernest/c (-> dim-sys? flat-contract?)]
+  ; TODO PARITY: Bring `punctaffy/hypersnippet/hypernest`'s
+  ; `hypernestof/ob-c`, `hypernest-snippet-sys`,
+  ; `hypernest-snippet-format-sys`, `hypernest-shape`,
+  ; `hypertee-bracket->hypernest-bracket`, and
+  ; `compatible-hypernest-bracket->hypertee-bracket` into parity with
+  ; this module, where they don't exist.
+  [hypernest-coil/c (-> dim-sys? flat-contract?)]
   [hypernest-from-brackets
     (->i
       (
@@ -132,6 +157,8 @@
           (hypernest-bracket/c dim/c)
           (and/c (not/c hypernest-bracket?) dim/c))]
       [_ (ds) (hypernest/c ds)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist.
   [hn-bracs-dss
     (->i
       (
@@ -149,18 +176,22 @@
           (and/c (not/c hypernest-bracket?) dim/c))]
       [_ (dss) (hypernest/c #/dim-successors-sys-dim-sys dss)])]
   [hypernest-get-brackets
-    (->i
-      ([hn hypernest?])
+    (->i ([hn hypernest?])
       [_ (hn)
-        (listof
-        #/hypernest-bracket/c
-        #/dim-sys-dim/c #/hypernest-dim-sys hn)])]
+        (w- ds (hypernest-dim-sys hn)
+        #/listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. If it
+  ; did exist, it would use a more specific contract that asserted the
+  ; result was of the requested degree.
   [hypernest-increase-degree-to
     (->i
       (
         [new-degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
         [hn hypernest?])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Continue looking for things to bring into parity from
+  ; here.
   [hypernest-set-degree-force
     (->i
       (
@@ -226,6 +257,9 @@
         [data any/c]
         [hole hypertee?])
       [_ (hole) (hypernest/c #/hypertee-dim-sys hole)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it's called
+  ; `hypernest-get-hole-zero-maybe` and has a more specific contract.
   [hypernest-get-hole-zero (-> hypernest? maybe?)]
   [hypernest-join-all-degrees
     (->i ([hn hypernest?])
@@ -276,6 +310,14 @@
         [new-degree (hn) (dim-sys-0<dim/c #/hypernest-dim-sys hn)]
         [hn hypernest?])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypernest-snippet-sys` and the not-yet-exported
+  ; `snippet-sys-snippet-join-list-and-tail-along-0`. If it did exist,
+  ; it might be called `hypernest-join-list-and-tail-along-0`, it
+  ; wouldn't take a `degree` argument, it would take a `last-snippet`
+  ; argument, and it would use a much more specific contract.
   [hypernest-append-zero
     (->i
       (
@@ -328,6 +370,11 @@
   (rename-contract (match/c hypernest (ok/c ds) any/c)
     `(hypernest/c ,ds)))
 
+; TODO PARITY: Bring this into parity with
+; `punctaffy/hypersnippet/hypernest`, where it checks that the tails
+; in the tails hypertee and tails hypernest fit into the holes they're
+; in.
+;
 (define (hypernest-coil/c ds)
   (rename-contract
     (or/c

--- a/punctaffy-lib/private/hypernest-as-ast.rkt
+++ b/punctaffy-lib/private/hypernest-as-ast.rkt
@@ -24,7 +24,6 @@
   -> ->i and/c any any/c contract? contract-name contract-out list/c
   listof not/c or/c rename-contract)
 (require #/only-in racket/contract/combinator coerce-contract)
-(require #/only-in racket/contract/region define/contract)
 (require #/only-in racket/math natural?)
 (require #/only-in racket/struct make-constructor-style-printer)
 
@@ -40,6 +39,9 @@
   auto-equal auto-write define-imitation-simple-struct struct-easy)
 (require #/only-in lathe-comforts/trivial trivial)
 (require #/only-in lathe-morphisms/in-fp/mediary/set ok/c)
+
+(require punctaffy/private/shim)
+(init-shim)
 
 (require #/only-in punctaffy/hypersnippet/dim
   dim-successors-sys? dim-sys? dim-successors-sys-dim-from-int
@@ -61,6 +63,7 @@
   unsafe-hypertee-from-brackets)
 (require #/only-in punctaffy/private/suppress-internal-errors
   punctaffy-suppress-internal-errors)
+
 
 (provide
   hnb-open)
@@ -720,7 +723,7 @@
 
 ; TODO: See if we'll ever use this. For now, we just have it here as
 ; an analogue to `unsafe-hypertee-from-brackets`.
-(define/contract (unsafe-hypernest-furl ds coil)
+(define/own-contract (unsafe-hypernest-furl ds coil)
   (-> dim-sys? any/c any)
   (unless (punctaffy-suppress-internal-errors)
     ; NOTE: At this point we don't expect
@@ -1056,7 +1059,7 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define/contract
+(define/own-contract
   (hypernest-dv-fold-map-any-all-degrees state hn on-hole)
   (->i
     (
@@ -1115,7 +1118,7 @@
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
 ;
-(define/contract
+(define/own-contract
   (hypernest-selective-holes-zip-map smaller bigger should-zip? func)
   (->i
     (
@@ -1168,7 +1171,7 @@
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
 ;
-(define/contract
+(define/own-contract
   (hypernest-low-degree-holes-zip-map smaller bigger func)
   (->i
     (
@@ -1197,7 +1200,7 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define/contract (hypernest-dgv-map-all-degrees hn func)
+(define/own-contract (hypernest-dgv-map-all-degrees hn func)
   (->i
     (
       [hn hypernest?]
@@ -1513,7 +1516,7 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define/contract
+(define/own-contract
   (hypernest-set-degree-and-bind-all-degrees new-degree hn hole-to-hn)
   (->i
     (
@@ -1566,7 +1569,7 @@
 ; TODO IMPLEMENT: Implement an operation analogous to this, but for
 ; hypertees instead of hypernests.
 ;
-(define/contract
+(define/own-contract
   (hypernest-set-degree-and-dv-bind-all-degrees
     new-degree hn dv-to-hn)
   (->i
@@ -1649,7 +1652,7 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define/contract (hypernest-dv-any-all-degrees hn func)
+(define/own-contract (hypernest-dv-any-all-degrees hn func)
   (->i
     (
       [hn hypernest?]
@@ -1677,7 +1680,7 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define/contract (hypernest-dv-each-all-degrees hn body)
+(define/own-contract (hypernest-dv-each-all-degrees hn body)
   (->i
     (
       [hn hypernest?]
@@ -1695,7 +1698,7 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define/contract (hypernest-each-all-degrees hn body)
+(define/own-contract (hypernest-each-all-degrees hn body)
   (-> hypernest? (-> hypertee? any/c any) void?)
   (hypernest-dv-each-all-degrees
     (hypernest-map-all-degrees hn #/fn hole data

--- a/punctaffy-lib/private/hypernest-as-ast.rkt
+++ b/punctaffy-lib/private/hypernest-as-ast.rkt
@@ -21,8 +21,8 @@
 
 
 (require #/only-in racket/contract/base
-  -> ->i and/c any any/c contract? contract-name contract-out
-  flat-contract? list/c listof not/c or/c rename-contract)
+  -> ->i and/c any any/c contract? contract-name flat-contract? list/c
+  listof not/c or/c rename-contract)
 (require #/only-in racket/contract/combinator coerce-contract)
 (require #/only-in racket/math natural?)
 (require #/only-in racket/struct make-constructor-style-printer)
@@ -67,52 +67,50 @@
 
 (provide
   hnb-open)
-(provide #/contract-out
-  [hnb-open? (-> any/c boolean?)]
-  [hnb-open-degree (-> hnb-open? any/c)]
-  [hnb-open-data (-> hnb-open? any/c)])
+(provide #/own-contract-out
+  hnb-open?
+  hnb-open-degree
+  hnb-open-data)
 (provide
   hnb-labeled)
-(provide #/contract-out
-  [hnb-labeled? (-> any/c boolean?)]
-  [hnb-labeled-degree (-> hnb-labeled? any/c)]
-  [hnb-labeled-data (-> hnb-labeled? any/c)])
+(provide #/own-contract-out
+  hnb-labeled?
+  hnb-labeled-degree
+  hnb-labeled-data)
 (provide
   hnb-unlabeled)
-(provide #/contract-out
-  [hnb-unlabeled? (-> any/c boolean?)]
-  [hnb-unlabeled-degree (-> hnb-unlabeled? any/c)])
-(provide #/contract-out
-  [hypernest-bracket? (-> any/c boolean?)]
-  [hypernest-bracket/c (-> contract? contract?)])
+(provide #/own-contract-out
+  hnb-unlabeled?
+  hnb-unlabeled-degree)
+(provide #/own-contract-out
+  hypernest-bracket?
+  hypernest-bracket/c)
 (provide
   hypernest-coil-zero)
-(provide #/contract-out
-  [hypernest-coil-zero? (-> any/c boolean?)])
+(provide #/own-contract-out
+  hypernest-coil-zero?)
 (provide
   hypernest-coil-hole)
-(provide #/contract-out
+(provide #/own-contract-out
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where there's an extra
   ; `hypernest-coil-hole-hole` field.
-  [hypernest-coil-hole? (-> any/c boolean?)]
-  [hypernest-coil-hole-overall-degree (-> hypernest-coil-hole? any/c)]
-  [hypernest-coil-hole-data (-> hypernest-coil-hole? any/c)]
-  [hypernest-coil-hole-tails-hypertee
-    (-> hypernest-coil-hole? any/c)])
+  hypernest-coil-hole?
+  hypernest-coil-hole-overall-degree
+  hypernest-coil-hole-data
+  hypernest-coil-hole-tails-hypertee)
 (provide
   hypernest-coil-bump)
-(provide #/contract-out
-  [hypernest-coil-bump? (-> any/c boolean?)]
-  [hypernest-coil-bump-overall-degree (-> hypernest-coil-bump? any/c)]
-  [hypernest-coil-bump-data (-> hypernest-coil-bump? any/c)]
-  [hypernest-coil-bump-bump-degree (-> hypernest-coil-bump? any/c)]
-  [hypernest-coil-bump-tails-hypernest
-    (-> hypernest-coil-bump? any/c)]
+(provide #/own-contract-out
+  hypernest-coil-bump?
+  hypernest-coil-bump-overall-degree
+  hypernest-coil-bump-data
+  hypernest-coil-bump-bump-degree
+  hypernest-coil-bump-tails-hypernest
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it's not exported.
-  [hypernest-bracket-degree (-> hypernest-bracket? any/c)]
-  [hypernest? (-> any/c boolean?)]
+  hypernest-bracket-degree
+  hypernest?
   ; TODO PARITY: Bring `hypernest-dim-sys` into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it's called
   ; `hypernest-get-dim-sys` and it's exported.
@@ -122,9 +120,7 @@
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it takes an extra `ds`
   ; argument and it's not exported.
-  [hypernest-degree
-    (->i ([hn hypernest?])
-      [_ (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)])]
+  hypernest-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it takes an extra `sfs`
   ; argument. (Actually, `punctaffy/hypersnippet/hypernest`'s
@@ -132,74 +128,30 @@
   ; of this one.)
   ; TODO DOCS: Consider more expressive hypernest contract combinators
   ; than `hypernest/c`, and come up with a new name for it.
-  [hypernest/c (-> dim-sys? flat-contract?)]
+  hypernest/c
   ; TODO PARITY: Bring `punctaffy/hypersnippet/hypernest`'s
   ; `hypernestof/ob-c`, `hypernest-snippet-sys`,
   ; `hypernest-snippet-format-sys`,
   ; `hypertee-bracket->hypernest-bracket`, and
   ; `compatible-hypernest-bracket->hypertee-bracket` into parity with
   ; this module, where they don't exist.
-  [hypernest-coil/c (-> dim-sys? flat-contract?)]
-  [hypernest-from-brackets
-    (->i
-      (
-        [ds dim-sys?]
-        [degree (ds) (dim-sys-dim/c ds)]
-        [brackets (ds)
-          (listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])
-      [_ (ds) (hypernest/c ds)])]
-  [hn-bracs
-    (->i ([ds dim-sys?] [degree (ds) (dim-sys-dim/c ds)])
-      #:rest
-      [brackets (ds)
-        (w- dim/c (dim-sys-dim/c ds)
-        #/listof #/or/c
-          (hypernest-bracket/c dim/c)
-          (and/c (not/c hypernest-bracket?) dim/c))]
-      [_ (ds) (hypernest/c ds)])]
+  hypernest-coil/c
+  hypernest-from-brackets
+  hn-bracs
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist.
-  [hn-bracs-dss
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [degree (dss)
-          (or/c natural?
-          #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])
-      #:rest
-      [brackets (dss)
-        (w- dim/c
-          (or/c natural?
-          #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)
-        #/listof #/or/c
-          (hypernest-bracket/c dim/c)
-          (and/c (not/c hypernest-bracket?) dim/c))]
-      [_ (dss) (hypernest/c #/dim-successors-sys-dim-sys dss)])]
-  [hypernest-get-brackets
-    (->i ([hn hypernest?])
-      [_ (hn)
-        (w- ds (hypernest-dim-sys hn)
-        #/listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])]
+  hn-bracs-dss
+  hypernest-get-brackets
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. If it
   ; did exist, it would use a more specific contract that asserted the
   ; result was of the requested degree.
-  [hypernest-increase-degree-to
-    (->i
-      (
-        [new-degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
-        [hn hypernest?])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-increase-degree-to
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. If it
   ; did exist, it would use a more specific contract that asserted the
   ; result was of the requested degree.
-  [hypernest-set-degree-force
-    (->i
-      (
-        [new-degree (hn) (dim-sys-0<dim/c #/hypernest-dim-sys hn)]
-        [hn hypernest?])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-set-degree-force
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys` and
@@ -207,7 +159,7 @@
   ; specific contract that asserted that the input abided by its own
   ; dimension system and that the result abided by the same dimension
   ; system and was of the same degree.
-  [hypertee->hypernest (-> hypertee? hypernest?)]
+  hypertee->hypernest
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys` and
@@ -215,25 +167,17 @@
   ; a more specific contract that asserted that the input abided by
   ; its own dimension system and that the result abided by the same
   ; dimension system and was of the same degree.
-  [hypernest->maybe-hypertee (-> hypernest? #/maybe/c hypertee?)]
+  hypernest->maybe-hypertee
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it's called
   ; `hypernest-shape` and takes an `hypernest-snippet-sys?` along with
   ; its other argument.
-  [hypernest-filter-to-hypertee
-    (->i ([hn hypernest?])
-      [_ (hn) (hypertee/c #/hypernest-dim-sys hn)])]
+  hypernest-filter-to-hypertee
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist.
   ; Lately, we've preferred `snippet-sys-snippet-done` for this
   ; purpose rather than associating dimensions with successors.
-  [hypernest-contour
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [hole-value any/c]
-        [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
-      [_ (dss) (hypernest/c #/dim-successors-sys-dim-sys dss)])]
+  hypernest-contour
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys` and
@@ -243,20 +187,11 @@
   ; the transformer function to return a maybe value for early
   ; exiting, and it would use a more specific contract that asserted
   ; the result was of the same degree as the hypernest argument.
-  [hypernest-holes-zip-map
-    (->i
-      (
-        [ht (hn) (hypertee/c #/hypernest-dim-sys hn)]
-        [hn hypernest?]
-        [func (hn)
-          (-> (hypertee/c #/hypernest-dim-sys hn) any/c any/c any/c)])
-      [_ (hn) (maybe/c #/hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-holes-zip-map
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it's called
   ; `hypernest-get-coil`.
-  [hypernest-unfurl
-    (->i ([hn hypernest?])
-      [_ (hn) (hypernest-coil/c #/hypernest-dim-sys hn)])]
+  hypernest-unfurl
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -265,13 +200,7 @@
   ; callback a hole shape rather than merely a degree, and it would
   ; use a more specific contract that asserted the result was of the
   ; same degree as the original.
-  [hypernest-dv-map-all-degrees
-    (->i
-      (
-        [hn hypernest?]
-        [func (hn)
-          (-> (dim-sys-dim/c #/hypernest-dim-sys hn) any/c any/c)])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-dv-map-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -281,43 +210,34 @@
   ; hole shape in addition to the value, and it would use a more
   ; specific contract that asserted the result was of the same degree
   ; as the original.
-  [hypernest-v-map-one-degree
-    (->i
-      (
-        [degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
-        [hn hypernest?]
-        [func (-> any/c any/c)])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])])
+  hypernest-v-map-one-degree)
 (provide
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/snippet`, where it's called `selected`.
   hypernest-join-selective-interpolation)
-(provide #/contract-out
-  [hypernest-join-selective-interpolation? (-> any/c boolean?)]
-  [hypernest-join-selective-interpolation-val
-    (-> hypernest-join-selective-interpolation? any/c)])
+(provide #/own-contract-out
+  hypernest-join-selective-interpolation?
+  hypernest-join-selective-interpolation-val)
 (provide
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/snippet`, where it's called `unselected`.
   hypernest-join-selective-non-interpolation)
-(provide #/contract-out
-  [hypernest-join-selective-non-interpolation? (-> any/c boolean?)]
-  [hypernest-join-selective-non-interpolation-val
-    (-> hypernest-join-selective-interpolation? any/c)]
+(provide #/own-contract-out
+  hypernest-join-selective-non-interpolation?
+  hypernest-join-selective-non-interpolation-val
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys` and
   ; `snippet-sys-snippet-join-selective`. If it did exist, it would be
   ; called `hypernest-join-selective`, and it would use a much more
   ; specific contract.
-  [hypernest-join-all-degrees-selective (-> hypernest? hypernest?)]
+  hypernest-join-all-degrees-selective
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys` and
   ; `snippet-sys-snippet-map`. If it did exist, it would be called
   ; `hypernest-map`, and it would use a much more specific contract.
-  [hypernest-map-all-degrees
-    (-> hypernest? (-> hypertee? any/c any/c) hypernest?)]
+  hypernest-map-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys` and
@@ -325,25 +245,17 @@
   ; hole shape argument before the data argument, and it would use a
   ; more specific contract that asserted the result was of the
   ; requested degree.
-  [hypernest-done
-    (->i
-      (
-        [degree (hole) (dim-sys-dim/c #/hypertee-dim-sys hole)]
-        [data any/c]
-        [hole hypertee?])
-      [_ (hole) (hypernest/c #/hypertee-dim-sys hole)])]
+  hypernest-done
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it's called
   ; `hypernest-get-hole-zero-maybe` and has a more specific contract.
-  [hypernest-get-hole-zero (-> hypernest? maybe?)]
+  hypernest-get-hole-zero
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys` and
   ; `snippet-sys-snippet-join`. If it did exist, it would be called
   ; `hypernest-join`, and it would use a much more specific contract.
-  [hypernest-join-all-degrees
-    (->i ([hn hypernest?])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-join-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -351,27 +263,13 @@
   ; exist, it would be called `hypernest-bind`, it would pass its
   ; callback a hole shape rather than merely a degree, and it would
   ; use a much more specific contract.
-  [hypernest-dv-bind-all-degrees
-    (->i
-      (
-        [hn hypernest?]
-        [dv-to-hn (hn)
-          (w- ds (hypernest-dim-sys hn)
-          #/-> (dim-sys-dim/c ds) any/c (hypernest/c ds))])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-dv-bind-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys` and
   ; `snippet-sys-snippet-bind`. If it did exist, it would be called
   ; `hypernest-bind`, and it would use a much more specific contract.
-  [hypernest-bind-all-degrees
-    (->i
-      (
-        [hn hypernest?]
-        [hole-to-hn (hn)
-          (w- ds (hypernest-dim-sys hn)
-          #/-> (hypertee/c ds) any/c (hypernest/c ds))])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-bind-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys`,
@@ -379,15 +277,7 @@
   ; `snippet-sys-snippet-bind-selective`. If it did exist, it would be
   ; called `hypernest-bind-if-degree=`, and it would use a much more
   ; specific contract.
-  [hypernest-bind-one-degree
-    (->i
-      (
-        [degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
-        [hn hypernest?]
-        [hole-to-hn (hn)
-          (w- ds (hypernest-dim-sys hn)
-          #/-> (hypertee/c ds) any/c (hypernest/c ds))])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-bind-one-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypernest-snippet-sys`,
@@ -395,12 +285,7 @@
   ; `snippet-sys-snippet-join-selective`. If it did exist, it would be
   ; called `hypernest-join-if-degree=`, and it would use a much more
   ; specific contract.
-  [hypernest-join-one-degree
-    (->i
-      (
-        [degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
-        [hn hypernest?])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-join-one-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -408,15 +293,7 @@
   ; `snippet-sys-snippet-set-degree-maybe`. If it did exist, it might
   ; be called `hypernest-set-degree-and-bind`, and it would use a much
   ; more specific contract.
-  [hypernest-set-degree-and-bind-highest-degrees
-    (->i
-      (
-        [new-degree (hn) (dim-sys-0<dim/c #/hypernest-dim-sys hn)]
-        [hn hypernest?]
-        [hole-to-hn (hn)
-          (w- ds (hypernest-dim-sys hn)
-          #/-> (hypertee/c ds) any/c (hypernest/c ds))])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-set-degree-and-bind-highest-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -424,12 +301,7 @@
   ; `snippet-sys-snippet-set-degree-maybe`. If it did exist, it might
   ; be called `hypernest-set-degree-and-join`, and it would use a much
   ; more specific contract.
-  [hypernest-set-degree-and-join-all-degrees
-    (->i
-      (
-        [new-degree (hn) (dim-sys-0<dim/c #/hypernest-dim-sys hn)]
-        [hn hypernest?])
-      [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  hypernest-set-degree-and-join-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -438,19 +310,11 @@
   ; it might be called `hypernest-join-list-and-tail-along-0`, it
   ; wouldn't take a `degree` argument, it would take a `last-snippet`
   ; argument, and it would use a much more specific contract.
-  [hypernest-append-zero
-    (->i
-      (
-        [ds dim-sys?]
-        [degree (ds) (dim-sys-0<dim/c ds)]
-        [hns (ds) (listof #/hypernest/c ds)])
-      [_ (ds) (hypernest/c ds)])]
+  hypernest-append-zero
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypernest`, where it doesn't have as
   ; strict a result contract and it has a match expander.
-  [hypernest-furl
-    (->i ([ds dim-sys?] [coil (ds) (hypernest-coil/c ds)])
-      [_ (ds) (hypernest/c ds)])])
+  hypernest-furl)
 
 
 ; ===== Hypernests ===================================================
@@ -458,6 +322,7 @@
 (define-imitation-simple-struct (hypernest-coil-zero?)
   hypernest-coil-zero
   'hypernest-coil-zero (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypernest-coil-zero? (-> any/c boolean?))
 (define-imitation-simple-struct
   (hypernest-coil-hole?
     hypernest-coil-hole-overall-degree
@@ -465,6 +330,13 @@
     hypernest-coil-hole-tails-hypertee)
   hypernest-coil-hole
   'hypernest-coil-hole (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypernest-coil-hole? (-> any/c boolean?))
+(ascribe-own-contract hypernest-coil-hole-overall-degree
+  (-> hypernest-coil-hole? any/c))
+(ascribe-own-contract hypernest-coil-hole-data
+  (-> hypernest-coil-hole? any/c))
+(ascribe-own-contract hypernest-coil-hole-tails-hypertee
+  (-> hypernest-coil-hole? any/c))
 (define-imitation-simple-struct
   (hypernest-coil-bump?
     hypernest-coil-bump-overall-degree
@@ -473,6 +345,15 @@
     hypernest-coil-bump-tails-hypernest)
   hypernest-coil-bump
   'hypernest-coil-bump (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypernest-coil-bump? (-> any/c boolean?))
+(ascribe-own-contract hypernest-coil-bump-overall-degree
+  (-> hypernest-coil-bump? any/c))
+(ascribe-own-contract hypernest-coil-bump-data
+  (-> hypernest-coil-bump? any/c))
+(ascribe-own-contract hypernest-coil-bump-bump-degree
+  (-> hypernest-coil-bump? any/c))
+(ascribe-own-contract hypernest-coil-bump-tails-hypernest
+  (-> hypernest-coil-bump? any/c))
 
 (define-imitation-simple-struct
   (hypernest? hypernest-dim-sys hypernest-coil)
@@ -488,8 +369,10 @@
         #/if (hypernest-bracket? bracket)
           (hnb-unlabeled bracket)
           bracket)))))
+(ascribe-own-contract hypernest? (-> any/c boolean?))
 
-(define (hypernest/c ds)
+(define/own-contract (hypernest/c ds)
+  (-> dim-sys? flat-contract?)
   (rename-contract (match/c hypernest (ok/c ds) any/c)
     `(hypernest/c ,ds)))
 
@@ -498,7 +381,8 @@
 ; in the tails hypertee and tails hypernest fit into the holes they're
 ; in.
 ;
-(define (hypernest-coil/c ds)
+(define/own-contract (hypernest-coil/c ds)
+  (-> dim-sys? flat-contract?)
   (rename-contract
     (or/c
       (match/c hypernest-coil-zero)
@@ -515,19 +399,29 @@
   (hnb-open? hnb-open-degree hnb-open-data)
   hnb-open
   'hnb-open (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hnb-open? (-> any/c boolean?))
+(ascribe-own-contract hnb-open-degree (-> hnb-open? any/c))
+(ascribe-own-contract hnb-open-data (-> hnb-open? any/c))
 (define-imitation-simple-struct
   (hnb-labeled? hnb-labeled-degree hnb-labeled-data)
   hnb-labeled
   'hnb-labeled (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hnb-labeled? (-> any/c boolean?))
+(ascribe-own-contract hnb-labeled-degree (-> hnb-labeled? any/c))
+(ascribe-own-contract hnb-labeled-data (-> hnb-labeled? any/c))
 (define-imitation-simple-struct
   (hnb-unlabeled? hnb-unlabeled-degree)
   hnb-unlabeled
   'hnb-unlabeled (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hnb-unlabeled? (-> any/c boolean?))
+(ascribe-own-contract hnb-unlabeled-degree (-> hnb-unlabeled? any/c))
 
-(define (hypernest-bracket? v)
+(define/own-contract (hypernest-bracket? v)
+  (-> any/c boolean?)
   (or (hnb-open? v) (hnb-labeled? v) (hnb-unlabeled? v)))
 
-(define (hypernest-bracket/c dim/c)
+(define/own-contract (hypernest-bracket/c dim/c)
+  (-> contract? contract?)
   (w- dim/c (coerce-contract 'hypernest-bracket/c dim/c)
   #/rename-contract
     (or/c
@@ -536,7 +430,8 @@
       (match/c hnb-unlabeled dim/c))
     `(hypernest-bracket/c ,(contract-name dim/c))))
 
-(define (hypernest-bracket-degree bracket)
+(define/own-contract (hypernest-bracket-degree bracket)
+  (-> hypernest-bracket? any/c)
   (mat bracket (hnb-open d data) d
   #/mat bracket (hnb-labeled d data) d
   #/dissect bracket (hnb-unlabeled d) d))
@@ -774,18 +669,48 @@
             (cons (hnb-unlabeled hole-degree) parent-rev-brackets)))
       #/next brackets-remaining parts updated-stack parent-i new-i))))
 
-(define (hypernest-from-brackets ds degree brackets)
+(define/own-contract (hypernest-from-brackets ds degree brackets)
+  (->i
+    (
+      [ds dim-sys?]
+      [degree (ds) (dim-sys-dim/c ds)]
+      [brackets (ds)
+        (listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])
+    [_ (ds) (hypernest/c ds)])
   (explicit-hypernest-from-brackets 'hypernest-from-brackets
     ds degree brackets))
 
-(define (hn-bracs ds degree . brackets)
+(define/own-contract (hn-bracs ds degree . brackets)
+  (->i ([ds dim-sys?] [degree (ds) (dim-sys-dim/c ds)])
+    #:rest
+    [brackets (ds)
+      (w- dim/c (dim-sys-dim/c ds)
+      #/listof #/or/c
+        (hypernest-bracket/c dim/c)
+        (and/c (not/c hypernest-bracket?) dim/c))]
+    [_ (ds) (hypernest/c ds)])
   (explicit-hypernest-from-brackets 'hn-bracs ds degree
   #/list-map brackets #/fn bracket
     (if (hypernest-bracket? bracket)
       bracket
       (hnb-unlabeled bracket))))
 
-(define (hn-bracs-dss dss degree . brackets)
+(define/own-contract (hn-bracs-dss dss degree . brackets)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [degree (dss)
+        (or/c natural?
+        #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])
+    #:rest
+    [brackets (dss)
+      (w- dim/c
+        (or/c natural?
+        #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)
+      #/listof #/or/c
+        (hypernest-bracket/c dim/c)
+        (and/c (not/c hypernest-bracket?) dim/c))]
+    [_ (dss) (hypernest/c #/dim-successors-sys-dim-sys dss)])
   (w- ds (dim-successors-sys-dim-sys dss)
   #/w- n-d
     (fn n
@@ -906,7 +831,9 @@
       (assert-valid-hypernest-coil 'unsafe-hypernest-furl ds coil)))
   (hypernest ds coil))
 
-(define (hypernest-furl ds coil)
+(define/own-contract (hypernest-furl ds coil)
+  (->i ([ds dim-sys?] [coil (ds) (hypernest-coil/c ds)])
+    [_ (ds) (hypernest/c ds)])
   ; NOTE: At this point we don't expect `assert-valid-hypernest-coil`
   ; itself to be very buggy. Since its implementation involves the
   ; construction of other hypertees and hypernests, we can save a
@@ -917,7 +844,9 @@
     (assert-valid-hypernest-coil 'hypernest-furl ds coil))
   (hypernest ds coil))
 
-(define (hypernest-degree hn)
+(define/own-contract (hypernest-degree hn)
+  (->i ([hn hypernest?])
+    [_ (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)])
   (dissect hn (hypernest ds coil)
   #/mat coil (hypernest-coil-zero) (dim-sys-dim-zero ds)
   #/mat coil (hypernest-coil-hole d data tails) d
@@ -925,7 +854,11 @@
     (hypernest-coil-bump overall-degree data bump-degree tails)
     overall-degree))
 
-(define (hypernest-get-brackets hn)
+(define/own-contract (hypernest-get-brackets hn)
+  (->i ([hn hypernest?])
+    [_ (hn)
+      (w- ds (hypernest-dim-sys hn)
+      #/listof #/hypernest-bracket/c #/dim-sys-dim/c ds)])
   (dissect hn (hypernest ds coil)
   #/w- interleave
     (fn overall-degree bump-degree tails #/let ()
@@ -1115,7 +1048,12 @@
 ; Takes a hypernest of any nonzero degree N and upgrades it to any
 ; degree N or greater, while leaving its bumps and holes the way they
 ; are.
-(define (hypernest-increase-degree-to new-degree hn)
+(define/own-contract (hypernest-increase-degree-to new-degree hn)
+  (->i
+    (
+      [new-degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
+      [hn hypernest?])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (dissect hn (hypernest ds coil)
   #/mat coil (hypernest-coil-zero)
     (error "Expected hn to be a hypernest of nonzero degree")
@@ -1146,7 +1084,12 @@
 ; Takes a nonzero-degree hypernest with no holes of degree N or
 ; greater and returns a degree-N hypernest with the same bumps and
 ; holes.
-(define (hypernest-set-degree-force new-degree hn)
+(define/own-contract (hypernest-set-degree-force new-degree hn)
+  (->i
+    (
+      [new-degree (hn) (dim-sys-0<dim/c #/hypernest-dim-sys hn)]
+      [hn hypernest?])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (dissect hn (hypernest ds coil)
   #/mat coil (hypernest-coil-zero)
     (error "Expected hn to be a hypernest of nonzero degree")
@@ -1177,7 +1120,8 @@
           data)
         data))))
 
-(define (hypertee->hypernest ht)
+(define/own-contract (hypertee->hypernest ht)
+  (-> hypertee? hypernest?)
   (w- ds (hypertee-dim-sys ht)
   #/hypernest-careful ds
   #/expect (hypertee-unfurl ht)
@@ -1187,7 +1131,8 @@
   #/hypertee-dv-map-all-degrees tails #/fn d tail
     (hypertee->hypernest tail)))
 
-(define (hypernest->maybe-hypertee hn)
+(define/own-contract (hypernest->maybe-hypertee hn)
+  (-> hypernest? #/maybe/c hypertee?)
   (dissect hn (hypernest ds coil)
   #/mat coil (hypernest-coil-zero)
     (just #/hypertee-furl ds #/hypertee-coil-zero)
@@ -1203,7 +1148,8 @@
     (hypernest-coil-bump overall-degree data bump-degree tails)
     (nothing)))
 
-(define (hypernest-filter-to-hypertee hn)
+(define/own-contract (hypernest-filter-to-hypertee hn)
+  (->i ([hn hypernest?]) [_ (hn) (hypertee/c #/hypernest-dim-sys hn)])
   (dissect hn (hypernest ds coil)
   #/mat coil (hypernest-coil-zero)
     (hypertee-furl ds #/hypertee-coil-zero)
@@ -1224,7 +1170,13 @@
 ; N+1 with all the same degree-less-than-N holes as well as a single
 ; degree-N hole in the shape of the original hypertee. This should
 ; be useful as something like a monadic return.
-(define (hypernest-contour dss hole-value ht)
+(define/own-contract (hypernest-contour dss hole-value ht)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [hole-value any/c]
+      [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
+    [_ (dss) (hypernest/c #/dim-successors-sys-dim-sys dss)])
   (hypertee->hypernest #/hypertee-contour dss hole-value ht))
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
@@ -1356,7 +1308,14 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define (hypernest-holes-zip-map ht hn func)
+(define/own-contract (hypernest-holes-zip-map ht hn func)
+  (->i
+    (
+      [ht (hn) (hypertee/c #/hypernest-dim-sys hn)]
+      [hn hypernest?]
+      [func (hn)
+        (-> (hypertee/c #/hypernest-dim-sys hn) any/c any/c any/c)])
+    [_ (hn) (maybe/c #/hypernest/c #/hypernest-dim-sys hn)])
   (w- ds (hypernest-dim-sys hn)
   #/expect
     (dim-sys-dim=? ds (hypertee-degree ht) (hypernest-degree hn))
@@ -1364,7 +1323,9 @@
     (error "Expected the hypertee and the hypernest to have the same degree")
   #/hypernest-low-degree-holes-zip-map ht hn func))
 
-(define (hypernest-unfurl hn)
+(define/own-contract (hypernest-unfurl hn)
+  (->i ([hn hypernest?])
+    [_ (hn) (hypernest-coil/c #/hypernest-dim-sys hn)])
   (dissect hn (hypernest ds coil)
     coil))
 
@@ -1411,11 +1372,23 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define (hypernest-dv-map-all-degrees hn func)
+(define/own-contract (hypernest-dv-map-all-degrees hn func)
+  (->i
+    (
+      [hn hypernest?]
+      [func (hn)
+        (-> (dim-sys-dim/c #/hypernest-dim-sys hn) any/c any/c)])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (hypernest-dgv-map-all-degrees hn #/fn d get-hole data
     (func d data)))
 
-(define (hypernest-v-map-one-degree degree hn func)
+(define/own-contract (hypernest-v-map-one-degree degree hn func)
+  (->i
+    (
+      [degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
+      [hn hypernest?]
+      [func (-> any/c any/c)])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (w- ds (hypernest-dim-sys hn)
   #/hypernest-dv-map-all-degrees hn #/fn hole-degree data
     (if (dim-sys-dim=? ds degree hole-degree)
@@ -1432,6 +1405,10 @@
   (current-inspector)
   (auto-write)
   (auto-equal))
+(ascribe-own-contract hypernest-join-selective-interpolation?
+  (-> any/c boolean?))
+(ascribe-own-contract hypernest-join-selective-interpolation-val
+  (-> hypernest-join-selective-interpolation? any/c))
 (define-imitation-simple-struct
   (hypernest-join-selective-non-interpolation?
     hypernest-join-selective-non-interpolation-val)
@@ -1440,6 +1417,10 @@
   (current-inspector)
   (auto-write)
   (auto-equal))
+(ascribe-own-contract hypernest-join-selective-non-interpolation?
+  (-> any/c boolean?))
+(ascribe-own-contract hypernest-join-selective-non-interpolation-val
+  (-> hypernest-join-selective-interpolation? any/c))
 
 ; This takes a hypernest of degree N where each hole value of each
 ; degree M is either a `hypernest-join-selective-interpolation`
@@ -1455,7 +1436,8 @@
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
 ;
-(define (hypernest-join-all-degrees-selective hn)
+(define/own-contract (hypernest-join-all-degrees-selective hn)
+  (-> hypernest? hypernest?)
   (dissect hn (hypernest ds coil)
   #/mat coil (hypernest-coil-zero)
     (hypernest-careful ds #/hypernest-coil-zero)
@@ -1588,7 +1570,8 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define (hypernest-map-all-degrees hn func)
+(define/own-contract (hypernest-map-all-degrees hn func)
+  (-> hypernest? (-> hypertee? any/c any/c) hypernest?)
   (hypernest-dgv-map-all-degrees hn #/fn d get-hole data
     (func (get-hole) data)))
 
@@ -1598,7 +1581,13 @@
 ;   hypertee-map-pred-degree
 ;   hypertee-map-highest-degree
 
-(define (hypernest-done degree data hole)
+(define/own-contract (hypernest-done degree data hole)
+  (->i
+    (
+      [degree (hole) (dim-sys-dim/c #/hypertee-dim-sys hole)]
+      [data any/c]
+      [hole hypertee?])
+    [_ (hole) (hypernest/c #/hypertee-dim-sys hole)])
   (w- ds (hypertee-dim-sys hole)
   #/expect (dim-sys-dim<? ds (hypertee-degree hole) degree) #t
     (raise-arguments-error 'hypernest-done
@@ -1607,7 +1596,8 @@
       "hole" hole)
   #/hypertee->hypernest #/hypertee-done degree data hole))
 
-(define (hypernest-get-hole-zero hn)
+(define/own-contract (hypernest-get-hole-zero hn)
+  (-> hypernest? maybe?)
   (dissect hn (hypernest ds coil)
   #/mat coil (hypernest-coil-zero)
     (nothing)
@@ -1637,7 +1627,9 @@
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
 ;
-(define (hypernest-join-all-degrees hn)
+(define/own-contract (hypernest-join-all-degrees hn)
+  (->i ([hn hypernest?])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (w- ds (hypernest-dim-sys hn)
   #/hypernest-join-all-degrees-selective
   #/hypernest-dv-map-all-degrees hn #/fn root-hole-degree data
@@ -1659,19 +1651,41 @@
 ; `hypertee-dv-bind-all-degrees`. Would it actually be more efficient
 ; at all?
 ;
-(define (hypernest-dv-bind-all-degrees hn dv-to-hn)
+(define/own-contract (hypernest-dv-bind-all-degrees hn dv-to-hn)
+  (->i
+    (
+      [hn hypernest?]
+      [dv-to-hn (hn)
+        (w- ds (hypernest-dim-sys hn)
+        #/-> (dim-sys-dim/c ds) any/c (hypernest/c ds))])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (hypernest-join-all-degrees
   #/hypernest-dv-map-all-degrees hn dv-to-hn))
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define (hypernest-bind-all-degrees hn hole-to-hn)
+(define/own-contract (hypernest-bind-all-degrees hn hole-to-hn)
+  (->i
+    (
+      [hn hypernest?]
+      [hole-to-hn (hn)
+        (w- ds (hypernest-dim-sys hn)
+        #/-> (hypertee/c ds) any/c (hypernest/c ds))])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (hypernest-join-all-degrees
   #/hypernest-map-all-degrees hn hole-to-hn))
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define (hypernest-bind-one-degree degree hn func)
+(define/own-contract (hypernest-bind-one-degree degree hn func)
+  (->i
+    (
+      [degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
+      [hn hypernest?]
+      [hole-to-hn (hn)
+        (w- ds (hypernest-dim-sys hn)
+        #/-> (hypertee/c ds) any/c (hypernest/c ds))])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (w- ds (hypernest-dim-sys hn)
   #/hypernest-bind-all-degrees hn #/fn hole data
     (if (dim-sys-dim=? ds degree #/hypertee-degree hole)
@@ -1680,7 +1694,12 @@
 
 ; TODO IMPLEMENT: Implement operations analogous to this, but for
 ; bumps instead of holes.
-(define (hypernest-join-one-degree degree hn)
+(define/own-contract (hypernest-join-one-degree degree hn)
+  (->i
+    (
+      [degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
+      [hn hypernest?])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (hypernest-bind-one-degree degree hn #/fn hole data
     data))
 
@@ -1723,9 +1742,17 @@
 ; TODO IMPLEMENT: Implement an operation analogous to this, but for
 ; hypertees instead of hypernests.
 ;
-(define
+(define/own-contract
   (hypernest-set-degree-and-bind-highest-degrees
     new-degree hn hole-to-hn)
+  (->i
+    (
+      [new-degree (hn) (dim-sys-0<dim/c #/hypernest-dim-sys hn)]
+      [hn hypernest?]
+      [hole-to-hn (hn)
+        (w- ds (hypernest-dim-sys hn)
+        #/-> (hypertee/c ds) any/c (hypernest/c ds))])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (w- ds (hypernest-dim-sys hn)
   #/hypernest-set-degree-and-bind-all-degrees new-degree hn
   #/fn hole data
@@ -1776,7 +1803,13 @@
 ; TODO IMPLEMENT: Implement an operation analogous to this, but for
 ; hypertees instead of hypernests.
 ;
-(define (hypernest-set-degree-and-join-all-degrees new-degree hn)
+(define/own-contract
+  (hypernest-set-degree-and-join-all-degrees new-degree hn)
+  (->i
+    (
+      [new-degree (hn) (dim-sys-0<dim/c #/hypernest-dim-sys hn)]
+      [hn hypernest?])
+    [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])
   (w- ds (hypernest-dim-sys hn)
   #/hypernest-set-degree-and-dv-bind-all-degrees new-degree hn
   #/fn hole-degree data
@@ -1794,7 +1827,13 @@
         "data" data)
       data)))
 
-(define (hypernest-append-zero ds degree hns)
+(define/own-contract (hypernest-append-zero ds degree hns)
+  (->i
+    (
+      [ds dim-sys?]
+      [degree (ds) (dim-sys-0<dim/c ds)]
+      [hns (ds) (listof #/hypernest/c ds)])
+    [_ (ds) (hypernest/c ds)])
   (begin
     ; TODO DOCS: See if we can verify these things in the contract.
     (list-each hns #/fn hn

--- a/punctaffy-lib/private/hypernest-as-ast.rkt
+++ b/punctaffy-lib/private/hypernest-as-ast.rkt
@@ -135,7 +135,7 @@
   [hypernest/c (-> dim-sys? flat-contract?)]
   ; TODO PARITY: Bring `punctaffy/hypersnippet/hypernest`'s
   ; `hypernestof/ob-c`, `hypernest-snippet-sys`,
-  ; `hypernest-snippet-format-sys`, `hypernest-shape`,
+  ; `hypernest-snippet-format-sys`,
   ; `hypertee-bracket->hypernest-bracket`, and
   ; `compatible-hypernest-bracket->hypertee-bracket` into parity with
   ; this module, where they don't exist.
@@ -190,19 +190,43 @@
         [new-degree (hn) (dim-sys-dim/c #/hypernest-dim-sys hn)]
         [hn hypernest?])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
-  ; TODO PARITY: Continue looking for things to bring into parity from
-  ; here.
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. If it
+  ; did exist, it would use a more specific contract that asserted the
+  ; result was of the requested degree.
   [hypernest-set-degree-force
     (->i
       (
         [new-degree (hn) (dim-sys-0<dim/c #/hypernest-dim-sys hn)]
         [hn hypernest?])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys` and
+  ; `snippet-sys-shape->snippet`. If it did exist, it would use a more
+  ; specific contract that asserted that the input abided by its own
+  ; dimension system and that the result abided by the same dimension
+  ; system and was of the same degree.
   [hypertee->hypernest (-> hypertee? hypernest?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys` and
+  ; `snippet-sys-snippet->maybe-shape`. If it did exist, it would use
+  ; a more specific contract that asserted that the input abided by
+  ; its own dimension system and that the result abided by the same
+  ; dimension system and was of the same degree.
   [hypernest->maybe-hypertee (-> hypernest? #/maybe/c hypertee?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it's called
+  ; `hypernest-shape` and takes an `hypernest-snippet-sys?` along with
+  ; its other argument.
   [hypernest-filter-to-hypertee
     (->i ([hn hypernest?])
       [_ (hn) (hypertee/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist.
+  ; Lately, we've preferred `snippet-sys-snippet-done` for this
+  ; purpose rather than associating dimensions with successors.
   [hypernest-contour
     (->i
       (
@@ -210,6 +234,15 @@
         [hole-value any/c]
         [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
       [_ (dss) (hypernest/c #/dim-successors-sys-dim-sys dss)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypernest-snippet-sys` and
+  ; `snippet-sys-snippet-zip-map`. If it did exist, it would be called
+  ; `hypernest-zip-map`, it would allow its hypertee argument to have
+  ; a degree less than that of its hypernest argument, it would allow
+  ; the transformer function to return a maybe value for early
+  ; exiting, and it would use a more specific contract that asserted
+  ; the result was of the same degree as the hypernest argument.
   [hypernest-holes-zip-map
     (->i
       (
@@ -218,9 +251,20 @@
         [func (hn)
           (-> (hypertee/c #/hypernest-dim-sys hn) any/c any/c any/c)])
       [_ (hn) (maybe/c #/hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it's called
+  ; `hypernest-get-coil`.
   [hypernest-unfurl
     (->i ([hn hypernest?])
       [_ (hn) (hypernest-coil/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypernest`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypernest-snippet-sys` and `snippet-sys-snippet-map`. If it did
+  ; exist, it would be called `hypernest-map`, it would pass its
+  ; callback a hole shape rather than merely a degree, and it would
+  ; use a more specific contract that asserted the result was of the
+  ; same degree as the original.
   [hypernest-dv-map-all-degrees
     (->i
       (
@@ -228,6 +272,8 @@
         [func (hn)
           (-> (dim-sys-dim/c #/hypernest-dim-sys hn) any/c any/c)])
       [_ (hn) (hypernest/c #/hypernest-dim-sys hn)])]
+  ; TODO PARITY: Continue looking for things to bring into parity from
+  ; here.
   [hypernest-v-map-one-degree
     (->i
       (

--- a/punctaffy-lib/private/hypernest-as-ast.rkt
+++ b/punctaffy-lib/private/hypernest-as-ast.rkt
@@ -5,7 +5,7 @@
 ; A data structure for encoding hypersnippet notations that can nest
 ; with themselves (represented in an AST style).
 
-;   Copyright 2018-2019, 2021 The Lathe Authors
+;   Copyright 2018-2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -202,8 +202,10 @@
     (->i ([ht hypertee?])
       [_ (ht) (hypertee-coil/c #/hypertee-dim-sys ht)])]
   ; TODO PARITY: Bring this into parity with
-  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
-  ; did exist, it would be called `hypertee-map`, it would pass its
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.  It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys` and `snippet-sys-snippet-map`. If it did
+  ; exist, it would be called `hypertee-map`, it would pass its
   ; callback a hole shape rather than merely a degree, and it would
   ; use a more specific contract that asserted the result was of the
   ; same degree as the original.
@@ -257,7 +259,7 @@
       [_ any/c])])
 (provide
   ; TODO PARITY: Bring this into parity with
-  ; `punctaffy/hypersnippet/hypertee`, where it's called `selected`.
+  ; `punctaffy/hypersnippet/snippet`, where it's called `selected`.
   hypertee-join-selective-interpolation)
 (provide #/contract-out
   [hypertee-join-selective-interpolation? (-> any/c boolean?)]
@@ -265,7 +267,7 @@
     (-> hypertee-join-selective-interpolation? any/c)])
 (provide
   ; TODO PARITY: Bring this into parity with
-  ; `punctaffy/hypersnippet/hypertee`, where it's called `unselected`.
+  ; `punctaffy/hypersnippet/snippet`, where it's called `unselected`.
   hypertee-join-selective-non-interpolation)
 (provide #/contract-out
   [hypertee-join-selective-non-interpolation? (-> any/c boolean?)]

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -75,6 +75,8 @@
 (provide #/contract-out
   [hypertee-bracket? (-> any/c boolean?)]
   [hypertee-bracket/c (-> contract? contract?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it's not exported.
   [hypertee-bracket-degree (-> hypertee-bracket? any/c)]
   [hypertee? (-> any/c boolean?)]
   ; TODO PARITY: Bring this into parity with
@@ -163,7 +165,9 @@
         [ht hypertee?])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
   ; TODO PARITY: Bring this into parity with
-  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. Lately,
+  ; we've preferred `snippet-sys-snippet-done` for this purpose rather
+  ; than associating dimensions with successors.
   [hypertee-contour
     (->i
       (
@@ -210,6 +214,9 @@
         [func (ht)
           (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring `punctaffy/hypersnippet/hypertee`'s
+  ; `hypertee-snippet-sys` and `hypertee-snippet-format-sys` into
+  ; parity with this module, where they don't exist.
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -485,11 +492,10 @@
   ; would use a more specific contract.
   [hypertee-each-all-degrees
     (-> hypertee? (-> hypertee? any/c any) void?)]
-  ; TODO PARITY: Continue looking for things to bring into parity from
-  ; here. Once we're done looking for them here, continue looking in
-  ; `punctaffy/private/hypernest-as-ast`, and look for things exported
-  ; by `punctaffy/hypersnippet/hypertee` and
-  ; `punctaffy/hypersnippet/hypernest` that these don't export.
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. Lately,
+  ; we've preferred `snippet-sys-snippet-undone` for this purpose
+  ; rather than associating dimensions with successors.
   [hypertee-uncontour
     (->i
       (
@@ -499,14 +505,33 @@
         (maybe/c #/list/c
           any/c
           (hypertee/c #/dim-successors-sys-dim-sys dss))])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys`, `snippet-sys-snippet-select`, and the
+  ; not-yet-exported `snippet-sys-snippet-filter-maybe`. If it did
+  ; exist, `hypertee-filter` is a fair name for it, and
+  ; `snippet-sys-snippet-filter-maybe` would probably be called
+  ; something else.
   [hypertee-filter
     (-> hypertee? (-> hypertee? any/c boolean?) hypertee?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys`, `snippet-sys-snippet-select-if-degree<`,
+  ; and the not-yet-exported `snippet-sys-snippet-filter-maybe`. If it
+  ; did exist, it would use a more specific contract that asserted the
+  ; result was of the requested degree.
   [hypertee-filter-degree-to
     (->i
       (
         [new-degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
         [ht hypertee?])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; might be related to the not-yet-exported `hypertee-map-cps` and
+  ; `hypertee-each-cps`.
   [hypertee-dv-fold-map-any-all-degrees
     (->i
       (
@@ -517,6 +542,17 @@
             (list/c any/c #/maybe/c any/c))])
       [_ (ht)
         (list/c any/c #/maybe/c #/hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypertee-snippet-sys` and
+  ; `snippet-sys-snippet-zip-map-selective`. If it did exist, it would
+  ; be called `hypertee-zip-map-selective`, it would allow its smaller
+  ; argument to have a degree less than that of its bigger argument,
+  ; it would expect its bigger argument to contain `selectable?`
+  ; values instead of taking a separate predicate, it would allow the
+  ;  transformer function to return a maybe value for early exiting,
+  ; and it would use a more specific contract that asserted the result
+  ; was of the same degree as the bigger argument.
   [hypertee-selective-holes-zip-map
     (->i
       (
@@ -529,6 +565,16 @@
           (-> (hypertee/c #/hypertee-dim-sys bigger) any/c any/c
             any/c)])
       [_ (bigger) (maybe/c #/hypertee/c #/hypertee-dim-sys bigger)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypertee-snippet-sys`,
+  ; `snippet-sys-snippet-select-if-degree<`, and
+  ; `snippet-sys-snippet-zip-map-selective`. If it did exist, it would
+  ; be called `hypertee-zip-map-if-degree<`, it would allow its
+  ; smaller argument to have a degree less than that of its bigger
+  ; argument, it would allow the transformer function to return a
+  ; maybe value for early exiting, and it would use a much more
+  ; specific contract.
   [hypertee-low-degree-holes-zip-map
     (-> hypertee? hypertee? (-> hypertee? any/c any/c any/c)
       (maybe/c hypertee?))])

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -22,8 +22,8 @@
 
 
 (require #/only-in racket/contract/base
-  -> ->i and/c any any/c contract? contract-name contract-out
-  flat-contract? list/c listof not/c or/c rename-contract)
+  -> ->i and/c any any/c contract? contract-name flat-contract? list/c
+  listof not/c or/c rename-contract)
 (require #/only-in racket/contract/combinator
   coerce-contract contract-first-order-passes?)
 (require #/only-in racket/math natural?)

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -267,10 +267,10 @@
 (provide #/contract-out
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
-  ; would probably be accommodated through a mix of
-  ; `hypertee-snippet-sys` and `snippet-sys-snippet-join-selective`.
-  ; If it did exist, it would be called `hypertee-join-selective`, and
-  ; it would use a much more specific contract.
+  ; would be accommodated through a mix of `hypertee-snippet-sys` and
+  ; `snippet-sys-snippet-join-selective`. If it did exist, it would be
+  ; called `hypertee-join-selective`, and it would use a much more
+  ; specific contract.
   [hypertee-join-all-degrees-selective (-> hypertee? hypertee?)]
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
@@ -280,12 +280,12 @@
     (-> hypertee? (-> hypertee? any/c any/c) hypertee?)]
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
-  ; would probably be accommodated through a mix of
-  ; `hypertee-snippet-sys`, `snippet-sys-snippet-select-if-degree`,
-  ; and `snippet-sys-snippet-map-selective`. If it did exist, it would
-  ; be called `hypertee-map-if-degree=`, and it would use a more
-  ; specific contract that asserted the result was of the same degree
-  ; as the original.
+  ; would be accommodated through a mix of `hypertee-snippet-sys`,
+  ; `snippet-sys-snippet-select-if-degree`, and
+  ; `snippet-sys-snippet-map-selective`. If it did exist, it would be
+  ; called `hypertee-map-if-degree=`, and it would use a more specific
+  ; contract that asserted the result was of the same degree as the
+  ; original.
   [hypertee-map-one-degree
     (->i
       (
@@ -334,11 +334,11 @@
   ; `snippet-sys-snippet-join`. If it did exist, it would be called
   ; `hypertee-join`, and it would use a much more specific contract.
   [hypertee-join-all-degrees (-> hypertee? hypertee?)]
-  ; TODO PARITY: Continue looking for things to bring into parity from
-  ; here. Once we're done looking for them here, continue looking in
-  ; `punctaffy/private/hypernest-as-ast`, and look for things exported
-  ; by `punctaffy/hypersnippet/hypertee` and
-  ; `punctaffy/hypersnippet/hypernest` that these don't export.
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypertee-snippet-sys` and
+  ; `snippet-sys-snippet-bind`. If it did exist, it would be called
+  ; `hypertee-bind`, and it would use a much more specific contract.
   [hypertee-bind-all-degrees
     (->i
       (
@@ -347,6 +347,13 @@
           (-> (hypertee/c #/hypertee-dim-sys ht) any/c
             (hypertee/c #/hypertee-dim-sys ht))])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypertee-snippet-sys`,
+  ; `snippet-sys-snippet-select-if-degree`, and
+  ; `snippet-sys-snippet-bind-selective`. If it did exist, it would be
+  ; called `hypertee-bind-if-degree=`, and it would use a much more
+  ; specific contract.
   [hypertee-bind-one-degree
     (->i
       (
@@ -356,6 +363,8 @@
           (-> (hypertee/c #/hypertee-dim-sys ht) any/c
             (hypertee/c #/hypertee-dim-sys ht))])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
   [hypertee-bind-pred-degree
     (->i
       (
@@ -366,12 +375,26 @@
           (w- ds (dim-successors-sys-dim-sys dss)
           #/-> (hypertee/c ds) any/c (hypertee/c ds))])
       [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypertee-snippet-sys`,
+  ; `snippet-sys-snippet-select-if-degree`, and
+  ; `snippet-sys-snippet-join-selective`. If it did exist, it would be
+  ; called `hypertee-join-if-degree=`, and it would use a much more
+  ; specific contract.
   [hypertee-join-one-degree
     (->i
       (
         [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
         [ht hypertee?])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys`, `snippet-sys-snippet-bind`, and
+  ; `snippet-sys-snippet-set-degree-maybe`. If it did exist, it might
+  ; be called `hypertee-set-degree-and-bind`, and it would use a much
+  ; more specific contract.
   [hypertee-set-degree-and-bind-all-degrees
     (->i
       (
@@ -381,6 +404,14 @@
           (w- ds (hypertee-dim-sys ht)
           #/-> (hypertee/c ds) any/c (hypertee/c ds))])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys` and the not-yet-exported
+  ; `snippet-sys-snippet-join-list-and-tail-along-0`. If it did exist,
+  ; it might be called `hypertee-join-list-and-tail-along-0`, it
+  ; wouldn't take a `degree` argument, it would take a `last-snippet`
+  ; argument, and it would use a much more specific contract.
   [hypertee-append-zero
     (->i
       (
@@ -388,6 +419,13 @@
         [degree (ds) (dim-sys-0<dim/c ds)]
         [hts (ds) (listof #/hypertee/c ds)])
       [_ (ds) (hypertee/c ds)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys` and `snippet-sys-snippet-any?`. If it did
+  ; exist, it would be called `hypertee-any?`, it would pass its
+  ; callback a hole shape rather than merely a degree, and it wouldn't
+  ; allow non-boolean results.
   [hypertee-dv-any-all-degrees
     (->i
       (
@@ -395,6 +433,13 @@
         [func (ht)
           (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
       [_ any/c])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys` and `snippet-sys-snippet-all?`. If it did
+  ; exist, it would be called `hypertee-all?`, it would pass its
+  ; callback a hole shape rather than merely a degree, and it wouldn't
+  ; allow non-boolean results.
   [hypertee-dv-all-all-degrees
     (->i
       (
@@ -402,6 +447,13 @@
         [func (ht)
           (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
       [_ any/c])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys` and `snippet-sys-snippet-each` or through
+  ; the not-yet-exported `hypertee-each-ltr`. If it did exist, it
+  ; would be called `hypertee-each` or `hypertee-each-ltr`, and it
+  ; would pass its callback a hole shape rather than merely a degree.
   [hypertee-dv-each-all-degrees
     (->i
       (
@@ -409,6 +461,14 @@
         [func (ht)
           (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any)])
       [_ void?])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys` and `snippet-sys-snippet-each` or through
+  ; the not-yet-exported `hypertee-each-ltr`. If it did exist, it
+  ; would be called `hypertee-each-if-degree=` or
+  ; `hypertee-each-ltr-if-degree=`, and it would pass its callback a
+  ; hole shape in addition to the value.
   [hypertee-v-each-one-degree
     (->i
       (
@@ -416,8 +476,20 @@
         [ht hypertee?]
         [body (ht) (-> any/c any)])
       [_ void?])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys` and `snippet-sys-snippet-each` or through
+  ; the not-yet-exported `hypertee-each-ltr`. If it did exist, it
+  ; would be called `hypertee-each` or `hypertee-each-ltr`, and it
+  ; would use a more specific contract.
   [hypertee-each-all-degrees
     (-> hypertee? (-> hypertee? any/c any) void?)]
+  ; TODO PARITY: Continue looking for things to bring into parity from
+  ; here. Once we're done looking for them here, continue looking in
+  ; `punctaffy/private/hypernest-as-ast`, and look for things exported
+  ; by `punctaffy/hypersnippet/hypertee` and
+  ; `punctaffy/hypersnippet/hypernest` that these don't export.
   [hypertee-uncontour
     (->i
       (
@@ -1680,7 +1752,7 @@
           "ht" ht)
       #/void))
   ; Now we know that the elements of `hts` are hypertees of degree
-  ; `degree` andthat  their degree-0 holes have trivial values as
+  ; `degree` and that their degree-0 holes have trivial values as
   ; contents. We return their degree-0 concatenation.
   #/list-foldr hts
     (ht-bracs ds degree #/htb-labeled (dim-sys-dim-zero ds) #/trivial)

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -47,6 +47,9 @@
 
 (require punctaffy/private/shim)
 (init-shim)
+(module+ unsafe
+  (require punctaffy/private/shim)
+  (init-shim))
 
 (require #/only-in punctaffy/hypersnippet/dim
   dim-successors-sys? dim-successors-sys-dim-from-int
@@ -63,144 +66,84 @@
 
 (provide
   htb-labeled)
-(provide #/contract-out
-  [htb-labeled? (-> any/c boolean?)]
-  [htb-labeled-degree (-> htb-labeled? any/c)]
-  [htb-labeled-data (-> htb-labeled? any/c)])
+(provide #/own-contract-out
+  htb-labeled?
+  htb-labeled-degree
+  htb-labeled-data)
 (provide
   htb-unlabeled)
-(provide #/contract-out
-  [htb-unlabeled? (-> any/c boolean?)]
-  [htb-unlabeled-degree (-> htb-unlabeled? any/c)])
-(provide #/contract-out
-  [hypertee-bracket? (-> any/c boolean?)]
-  [hypertee-bracket/c (-> contract? contract?)]
+(provide #/own-contract-out
+  htb-unlabeled?
+  htb-unlabeled-degree)
+(provide #/own-contract-out
+  hypertee-bracket?
+  hypertee-bracket/c
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it's not exported.
-  [hypertee-bracket-degree (-> hypertee-bracket? any/c)]
-  [hypertee? (-> any/c boolean?)]
+  hypertee-bracket-degree
+  hypertee?
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it's called
   ; `hypertee-get-dim-sys`.
-  [hypertee-dim-sys (-> hypertee? dim-sys?)]
+  hypertee-dim-sys
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it isn't exported.
-  [hypertee-degree
-    (->i ([ht hypertee?])
-      [_ (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)])]
+  hypertee-degree
   ; TODO DOCS: Consider more expressive hypertee contract combinators
   ; than `hypertee/c`, and come up with a new name for it.
-  [hypertee/c (-> dim-sys? flat-contract?)])
-(module+ unsafe #/provide #/contract-out
-  [unsafe-hypertee-from-brackets (-> dim-sys? any/c any/c any)])
-(provide #/contract-out
-  [hypertee-from-brackets
-    (->i
-      (
-        [ds dim-sys?]
-        [degree (ds) (dim-sys-dim/c ds)]
-        [brackets (ds)
-          (listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])
-      [_ (ds) (hypertee/c ds)])]
-  [ht-bracs
-    (->i ([ds dim-sys?] [degree (ds) (dim-sys-dim/c ds)])
-      #:rest
-      [brackets (ds)
-        (w- dim/c (dim-sys-dim/c ds)
-        #/listof #/or/c
-          (hypertee-bracket/c dim/c)
-          (and/c (not/c hypertee-bracket?) dim/c))]
-      [_ (ds) (hypertee/c ds)])]
+  hypertee/c)
+(module+ unsafe #/provide #/own-contract-out
+  unsafe-hypertee-from-brackets)
+(provide #/own-contract-out
+  hypertee-from-brackets
+  ht-bracs
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
-  [ht-bracs-dss
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [degree (dss)
-          (or/c natural?
-          #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])
-      #:rest
-      [brackets (dss)
-        (w- dim/c
-          (or/c natural?
-          #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)
-        #/listof #/or/c
-          (hypertee-bracket/c dim/c)
-          (and/c (not/c hypertee-bracket?) dim/c))]
-      [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])]
-  [hypertee-get-brackets
-    (->i ([ht hypertee?])
-      [_ (ht)
-        (w- ds (hypertee-dim-sys ht)
-        #/listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])]
+  ht-bracs-dss
+  hypertee-get-brackets
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
   ; did exist, it would use a more specific contract that asserted the
   ; result was of the requested degree.
-  [hypertee-increase-degree-to
-    (->i
-      (
-        [new-degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-increase-degree-to
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
   ; did exist, it would use a more specific contract that asserted the
   ; result was of the requested degree.
-  [hypertee-set-degree-maybe
-    (->i
-      (
-        [new-degree (ht) (dim-sys-0<dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?])
-      [_ (ht) (maybe/c #/hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-set-degree-maybe
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
   ; did exist, it would use a more specific contract that asserted the
   ; result was of the requested degree.
-  [hypertee-set-degree-force
-    (->i
-      (
-        [new-degree (ht) (dim-sys-0<dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-set-degree-force
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. Lately,
   ; we've preferred `snippet-sys-snippet-done` for this purpose rather
   ; than associating dimensions with successors.
-  [hypertee-contour
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [hole-value any/c]
-        [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
-      [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])])
+  hypertee-contour)
 (provide
   hypertee-coil-zero)
-(provide #/contract-out
-  [hypertee-coil-zero? (-> any/c boolean?)])
+(provide #/own-contract-out
+  hypertee-coil-zero?)
 (provide
   hypertee-coil-hole)
-(provide #/contract-out
+(provide #/own-contract-out
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where there's an extra
   ; `hypertee-coil-hole-hole` field and
   ; `hypertee-coil-hole-tails-hypertee` is called
   ; `hypertee-coil-hole-tails`.
-  [hypertee-coil-hole? (-> any/c boolean?)]
-  [hypertee-coil-hole-overall-degree (-> hypertee-coil-hole? any/c)]
-  [hypertee-coil-hole-data (-> hypertee-coil-hole? any/c)]
-  [hypertee-coil-hole-tails-hypertee
-    (-> hypertee-coil-hole? any/c)])
-(provide #/contract-out
-  [hypertee-coil/c (-> dim-sys? flat-contract?)])
-(provide #/contract-out
+  hypertee-coil-hole?
+  hypertee-coil-hole-overall-degree
+  hypertee-coil-hole-data
+  hypertee-coil-hole-tails-hypertee)
+(provide #/own-contract-out
+  hypertee-coil/c)
+(provide #/own-contract-out
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it's called
   ; `hypertee-get-coil`.
-  [hypertee-unfurl
-    (->i ([ht hypertee?])
-      [_ (ht) (hypertee-coil/c #/hypertee-dim-sys ht)])]
+  hypertee-unfurl
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.  It
   ; would probably be accommodated through a mix of
@@ -209,13 +152,7 @@
   ; callback a hole shape rather than merely a degree, and it would
   ; use a more specific contract that asserted the result was of the
   ; same degree as the original.
-  [hypertee-dv-map-all-degrees
-    (->i
-      (
-        [ht hypertee?]
-        [func (ht)
-          (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-dv-map-all-degrees
   ; TODO PARITY: Bring `punctaffy/hypersnippet/hypertee`'s
   ; `hypertee-snippet-sys` and `hypertee-snippet-format-sys` into
   ; parity with this module, where they don't exist.
@@ -228,66 +165,41 @@
   ; hole shape in addition to the value, and it would use a more
   ; specific contract that asserted the result was of the same degree
   ; as the original.
-  [hypertee-v-map-one-degree
-    (->i
-      (
-        [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?]
-        [func (-> any/c any/c)])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-v-map-one-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
-  [hypertee-v-map-highest-degree
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)]
-        [func (-> any/c any/c)])
-      [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])]
+  hypertee-v-map-highest-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
-  [hypertee-fold
-    (->i
-      (
-        [first-nontrivial-d (ht)
-          (dim-sys-dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?]
-        [on-zero (-> any/c)]
-        [on-hole (ht)
-          (w- ds (hypertee-dim-sys ht)
-          #/-> (dim-sys-dim/c ds) any/c (hypertee/c ds) any/c)])
-      [_ any/c])])
+  hypertee-fold)
 (provide
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/snippet`, where it's called `selected`.
   hypertee-join-selective-interpolation)
-(provide #/contract-out
-  [hypertee-join-selective-interpolation? (-> any/c boolean?)]
-  [hypertee-join-selective-interpolation-val
-    (-> hypertee-join-selective-interpolation? any/c)])
+(provide #/own-contract-out
+  hypertee-join-selective-interpolation?
+  hypertee-join-selective-interpolation-val)
 (provide
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/snippet`, where it's called `unselected`.
   hypertee-join-selective-non-interpolation)
-(provide #/contract-out
-  [hypertee-join-selective-non-interpolation? (-> any/c boolean?)]
-  [hypertee-join-selective-non-interpolation-val
-    (-> hypertee-join-selective-interpolation? any/c)])
-(provide #/contract-out
+(provide #/own-contract-out
+  hypertee-join-selective-non-interpolation?
+  hypertee-join-selective-non-interpolation-val)
+(provide #/own-contract-out
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys` and
   ; `snippet-sys-snippet-join-selective`. If it did exist, it would be
   ; called `hypertee-join-selective`, and it would use a much more
   ; specific contract.
-  [hypertee-join-all-degrees-selective (-> hypertee? hypertee?)]
+  hypertee-join-all-degrees-selective
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys` and
   ; `snippet-sys-snippet-map`. If it did exist, it would be called
   ; `hypertee-map`, and it would use a much more specific contract.
-  [hypertee-map-all-degrees
-    (-> hypertee? (-> hypertee? any/c any/c) hypertee?)]
+  hypertee-map-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys`,
@@ -296,24 +208,10 @@
   ; called `hypertee-map-if-degree=`, and it would use a more specific
   ; contract that asserted the result was of the same degree as the
   ; original.
-  [hypertee-map-one-degree
-    (->i
-      (
-        [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?]
-        [func (ht) (-> (hypertee/c #/hypertee-dim-sys ht) any/c any/c)])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-map-one-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
-  [hypertee-map-highest-degree
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)]
-        [func (dss)
-          (-> (hypertee/c #/dim-successors-sys-dim-sys dss) any/c
-            any/c)])
-      [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])]
+  hypertee-map-highest-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys` and
@@ -321,42 +219,27 @@
   ; hole shape argument before the data argument, and it would use a
   ; more specific contract that asserted the result was of the
   ; requested degree.
-  [hypertee-done
-    (->i
-      (
-        [degree (hole) (dim-sys-dim/c #/hypertee-dim-sys hole)]
-        [data any/c]
-        [hole hypertee?])
-      [_ (hole) (hypertee/c #/hypertee-dim-sys hole)])]
+  hypertee-done
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it's called
   ; `hypertee-get-hole-zero-maybe` and has a more specific contract.
-  [hypertee-get-hole-zero (-> hypertee? maybe?)]
+  hypertee-get-hole-zero
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't have as strict
   ; a result contract and it has a match expander.
-  [hypertee-furl
-    (->i ([ds dim-sys?] [coil (ds) (hypertee-coil/c ds)])
-      [_ (ds) (hypertee/c ds)])]
+  hypertee-furl
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys` and
   ; `snippet-sys-snippet-join`. If it did exist, it would be called
   ; `hypertee-join`, and it would use a much more specific contract.
-  [hypertee-join-all-degrees (-> hypertee? hypertee?)]
+  hypertee-join-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys` and
   ; `snippet-sys-snippet-bind`. If it did exist, it would be called
   ; `hypertee-bind`, and it would use a much more specific contract.
-  [hypertee-bind-all-degrees
-    (->i
-      (
-        [ht hypertee?]
-        [func (ht)
-          (-> (hypertee/c #/hypertee-dim-sys ht) any/c
-            (hypertee/c #/hypertee-dim-sys ht))])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-bind-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys`,
@@ -364,27 +247,10 @@
   ; `snippet-sys-snippet-bind-selective`. If it did exist, it would be
   ; called `hypertee-bind-if-degree=`, and it would use a much more
   ; specific contract.
-  [hypertee-bind-one-degree
-    (->i
-      (
-        [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?]
-        [func (ht)
-          (-> (hypertee/c #/hypertee-dim-sys ht) any/c
-            (hypertee/c #/hypertee-dim-sys ht))])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-bind-one-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
-  [hypertee-bind-pred-degree
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [degree (dss) (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
-        [ht hypertee?]
-        [func (dss)
-          (w- ds (dim-successors-sys-dim-sys dss)
-          #/-> (hypertee/c ds) any/c (hypertee/c ds))])
-      [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])]
+  hypertee-bind-pred-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys`,
@@ -392,12 +258,7 @@
   ; `snippet-sys-snippet-join-selective`. If it did exist, it would be
   ; called `hypertee-join-if-degree=`, and it would use a much more
   ; specific contract.
-  [hypertee-join-one-degree
-    (->i
-      (
-        [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-join-one-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -405,15 +266,7 @@
   ; `snippet-sys-snippet-set-degree-maybe`. If it did exist, it might
   ; be called `hypertee-set-degree-and-bind`, and it would use a much
   ; more specific contract.
-  [hypertee-set-degree-and-bind-all-degrees
-    (->i
-      (
-        [new-degree (ht) (dim-sys-0<dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?]
-        [hole-to-ht (ht)
-          (w- ds (hypertee-dim-sys ht)
-          #/-> (hypertee/c ds) any/c (hypertee/c ds))])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-set-degree-and-bind-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -422,13 +275,7 @@
   ; it might be called `hypertee-join-list-and-tail-along-0`, it
   ; wouldn't take a `degree` argument, it would take a `last-snippet`
   ; argument, and it would use a much more specific contract.
-  [hypertee-append-zero
-    (->i
-      (
-        [ds dim-sys?]
-        [degree (ds) (dim-sys-0<dim/c ds)]
-        [hts (ds) (listof #/hypertee/c ds)])
-      [_ (ds) (hypertee/c ds)])]
+  hypertee-append-zero
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -436,13 +283,7 @@
   ; exist, it would be called `hypertee-any?`, it would pass its
   ; callback a hole shape rather than merely a degree, and it wouldn't
   ; allow non-boolean results.
-  [hypertee-dv-any-all-degrees
-    (->i
-      (
-        [ht hypertee?]
-        [func (ht)
-          (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
-      [_ any/c])]
+  hypertee-dv-any-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -450,13 +291,7 @@
   ; exist, it would be called `hypertee-all?`, it would pass its
   ; callback a hole shape rather than merely a degree, and it wouldn't
   ; allow non-boolean results.
-  [hypertee-dv-all-all-degrees
-    (->i
-      (
-        [ht hypertee?]
-        [func (ht)
-          (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
-      [_ any/c])]
+  hypertee-dv-all-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -464,13 +299,7 @@
   ; the not-yet-exported `hypertee-each-ltr`. If it did exist, it
   ; would be called `hypertee-each` or `hypertee-each-ltr`, and it
   ; would pass its callback a hole shape rather than merely a degree.
-  [hypertee-dv-each-all-degrees
-    (->i
-      (
-        [ht hypertee?]
-        [func (ht)
-          (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any)])
-      [_ void?])]
+  hypertee-dv-each-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -479,13 +308,7 @@
   ; would be called `hypertee-each-if-degree=` or
   ; `hypertee-each-ltr-if-degree=`, and it would pass its callback a
   ; hole shape in addition to the value.
-  [hypertee-v-each-one-degree
-    (->i
-      (
-        [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?]
-        [body (ht) (-> any/c any)])
-      [_ void?])]
+  hypertee-v-each-one-degree
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -493,21 +316,12 @@
   ; the not-yet-exported `hypertee-each-ltr`. If it did exist, it
   ; would be called `hypertee-each` or `hypertee-each-ltr`, and it
   ; would use a more specific contract.
-  [hypertee-each-all-degrees
-    (-> hypertee? (-> hypertee? any/c any) void?)]
+  hypertee-each-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. Lately,
   ; we've preferred `snippet-sys-snippet-undone` for this purpose
   ; rather than associating dimensions with successors.
-  [hypertee-uncontour
-    (->i
-      (
-        [dss dim-successors-sys?]
-        [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
-      [_ (dss)
-        (maybe/c #/list/c
-          any/c
-          (hypertee/c #/dim-successors-sys-dim-sys dss))])]
+  hypertee-uncontour
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -516,8 +330,7 @@
   ; exist, `hypertee-filter` is a fair name for it, and
   ; `snippet-sys-snippet-filter-maybe` would probably be called
   ; something else.
-  [hypertee-filter
-    (-> hypertee? (-> hypertee? any/c boolean?) hypertee?)]
+  hypertee-filter
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would probably be accommodated through a mix of
@@ -525,26 +338,12 @@
   ; and the not-yet-exported `snippet-sys-snippet-filter-maybe`. If it
   ; did exist, it would use a more specific contract that asserted the
   ; result was of the requested degree.
-  [hypertee-filter-degree-to
-    (->i
-      (
-        [new-degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
-        [ht hypertee?])
-      [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-filter-degree-to
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; might be related to the not-yet-exported `hypertee-map-cps` and
   ; `hypertee-each-cps`.
-  [hypertee-dv-fold-map-any-all-degrees
-    (->i
-      (
-        [state any/c]
-        [ht hypertee?]
-        [on-hole (ht)
-          (-> any/c (dim-sys-dim/c #/hypertee-dim-sys ht) any/c
-            (list/c any/c #/maybe/c any/c))])
-      [_ (ht)
-        (list/c any/c #/maybe/c #/hypertee/c #/hypertee-dim-sys ht)])]
+  hypertee-dv-fold-map-any-all-degrees
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys` and
@@ -556,18 +355,7 @@
   ;  transformer function to return a maybe value for early exiting,
   ; and it would use a more specific contract that asserted the result
   ; was of the same degree as the bigger argument.
-  [hypertee-selective-holes-zip-map
-    (->i
-      (
-        [smaller (bigger) (hypertee/c #/hypertee-dim-sys bigger)]
-        [bigger hypertee?]
-        [should-zip? (bigger)
-          (-> (hypertee/c #/hypertee-dim-sys bigger) any/c
-            boolean?)]
-        [func (bigger)
-          (-> (hypertee/c #/hypertee-dim-sys bigger) any/c any/c
-            any/c)])
-      [_ (bigger) (maybe/c #/hypertee/c #/hypertee-dim-sys bigger)])]
+  hypertee-selective-holes-zip-map
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
   ; would be accommodated through a mix of `hypertee-snippet-sys`,
@@ -578,9 +366,7 @@
   ; argument, it would allow the transformer function to return a
   ; maybe value for early exiting, and it would use a much more
   ; specific contract.
-  [hypertee-low-degree-holes-zip-map
-    (-> hypertee? hypertee? (-> hypertee? any/c any/c any/c)
-      (maybe/c hypertee?))])
+  hypertee-low-degree-holes-zip-map)
 
 
 ; ===== Hypertees ====================================================
@@ -919,15 +705,22 @@
   (htb-labeled? htb-labeled-degree htb-labeled-data)
   htb-labeled
   'htb-labeled (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract htb-labeled? (-> any/c boolean?))
+(ascribe-own-contract htb-labeled-degree (-> htb-labeled? any/c))
+(ascribe-own-contract htb-labeled-data (-> htb-labeled? any/c))
 (define-imitation-simple-struct
   (htb-unlabeled? htb-unlabeled-degree)
   htb-unlabeled
   'htb-unlabeled (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract htb-unlabeled? (-> any/c boolean?))
+(ascribe-own-contract htb-unlabeled-degree (-> htb-unlabeled? any/c))
 
-(define (hypertee-bracket? v)
+(define/own-contract (hypertee-bracket? v)
+  (-> any/c boolean?)
   (or (htb-labeled? v) (htb-unlabeled? v)))
 
-(define (hypertee-bracket/c dim/c)
+(define/own-contract (hypertee-bracket/c dim/c)
+  (-> contract? contract?)
   (w- dim/c (coerce-contract 'hypertee-bracket/c dim/c)
   #/rename-contract
     (or/c
@@ -935,7 +728,8 @@
       (match/c htb-unlabeled dim/c))
     `(hypertee-bracket/c ,(contract-name dim/c))))
 
-(define (hypertee-bracket-degree closing-bracket)
+(define/own-contract (hypertee-bracket-degree closing-bracket)
+  (-> hypertee-bracket? any/c)
   (mat closing-bracket (htb-labeled d data) d
   #/dissect closing-bracket (htb-unlabeled d) d))
 
@@ -1001,6 +795,11 @@
         #/if (hypertee-bracket? bracket)
           (htb-unlabeled bracket)
           bracket)))))
+(ascribe-own-contract hypertee? (-> any/c boolean?))
+(ascribe-own-contract hypertee-dim-sys (-> hypertee? dim-sys?))
+(ascribe-own-contract hypertee-degree
+  (->i ([ht hypertee?])
+    [_ (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]))
 
 (define-match-expander-attenuated
   attenuated-hypertee unguarded-hypertee
@@ -1015,11 +814,14 @@
 (define-match-expander-from-match-and-make
   hypertee unguarded-hypertee attenuated-hypertee attenuated-hypertee)
 
-(define (hypertee/c ds)
+(define/own-contract (hypertee/c ds)
+  (-> dim-sys? flat-contract?)
   (rename-contract (match/c hypertee (ok/c ds) any/c any/c)
     `(hypertee/c ,ds)))
 
-(define (unsafe-hypertee-from-brackets ds degree closing-brackets)
+(define/own-contract
+  (unsafe-hypertee-from-brackets ds degree closing-brackets)
+  (-> dim-sys? any/c any/c any)
   (unless (punctaffy-suppress-internal-errors)
     (assert-valid-hypertee-brackets 'unsafe-hypertee-from-brackets
       ds degree closing-brackets))
@@ -1029,18 +831,48 @@
   (assert-valid-hypertee-brackets err-name ds degree brackets)
   (unguarded-hypertee ds degree brackets))
 
-(define (hypertee-from-brackets ds degree brackets)
+(define/own-contract (hypertee-from-brackets ds degree brackets)
+  (->i
+    (
+      [ds dim-sys?]
+      [degree (ds) (dim-sys-dim/c ds)]
+      [brackets (ds)
+        (listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])
+    [_ (ds) (hypertee/c ds)])
   (explicit-hypertee-from-brackets 'hypertee-from-brackets
     ds degree brackets))
 
-(define (ht-bracs ds degree . brackets)
+(define/own-contract (ht-bracs ds degree . brackets)
+  (->i ([ds dim-sys?] [degree (ds) (dim-sys-dim/c ds)])
+    #:rest
+    [brackets (ds)
+      (w- dim/c (dim-sys-dim/c ds)
+      #/listof #/or/c
+        (hypertee-bracket/c dim/c)
+        (and/c (not/c hypertee-bracket?) dim/c))]
+    [_ (ds) (hypertee/c ds)])
   (explicit-hypertee-from-brackets 'ht-bracs ds degree
   #/list-map brackets #/fn closing-bracket
     (if (hypertee-bracket? closing-bracket)
       closing-bracket
       (htb-unlabeled closing-bracket))))
 
-(define (ht-bracs-dss dss degree . brackets)
+(define/own-contract (ht-bracs-dss dss degree . brackets)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [degree (dss)
+        (or/c natural?
+        #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)])
+    #:rest
+    [brackets (dss)
+      (w- dim/c
+        (or/c natural?
+        #/dim-sys-dim/c #/dim-successors-sys-dim-sys dss)
+      #/listof #/or/c
+        (hypertee-bracket/c dim/c)
+        (and/c (not/c hypertee-bracket?) dim/c))]
+    [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
   (w- ds (dim-successors-sys-dim-sys dss)
   #/w- n-d
     (fn n
@@ -1056,13 +888,22 @@
     #/mat bracket (htb-unlabeled d) (htb-unlabeled (n-d d))
     #/htb-unlabeled (n-d bracket))))
 
-(define (hypertee-get-brackets ht)
+(define/own-contract (hypertee-get-brackets ht)
+  (->i ([ht hypertee?])
+    [_ (ht)
+      (w- ds (hypertee-dim-sys ht)
+      #/listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])
   (dissect ht (hypertee ds d closing-brackets)
     closing-brackets))
 
 ; Takes a hypertee of any nonzero degree N and upgrades it to any
 ; degree N or greater, while leaving its holes the way they are.
-(define (hypertee-increase-degree-to new-degree ht)
+(define/own-contract (hypertee-increase-degree-to new-degree ht)
+  (->i
+    (
+      [new-degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (dissect ht (hypertee ds d closing-brackets)
   #/if (dim-sys-dim=0? ds d)
     (raise-arguments-error 'hypertee-increase-degree-to
@@ -1079,7 +920,12 @@
 ; hypertee with the same holes if possible. If this isn't possible
 ; (because some holes in the original are of degree N or greater),
 ; this returns `(nothing)`.
-(define (hypertee-set-degree-maybe new-degree ht)
+(define/own-contract (hypertee-set-degree-maybe new-degree ht)
+  (->i
+    (
+      [new-degree (ht) (dim-sys-0<dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?])
+    [_ (ht) (maybe/c #/hypertee/c #/hypertee-dim-sys ht)])
   (dissect ht (hypertee ds d closing-brackets)
   #/if (dim-sys-dim=0? ds d)
     (raise-arguments-error 'hypertee-set-degree-maybe
@@ -1095,7 +941,12 @@
 
 ; Takes a nonzero-degree hypertee with no holes of degree N or greater
 ; and returns a degree-N hypertee with the same holes.
-(define (hypertee-set-degree-force new-degree ht)
+(define/own-contract (hypertee-set-degree-force new-degree ht)
+  (->i
+    (
+      [new-degree (ht) (dim-sys-0<dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (expect (hypertee-set-degree-maybe new-degree ht) (just result)
     (error "Expected ht to have no holes of degree new-degree or greater")
     result))
@@ -1104,7 +955,13 @@
 ; N+1 with all the same degree-less-than-N holes as well as a single
 ; degree-N hole in the shape of the original hypertee. This should
 ; be useful as something like a monadic return.
-(define (hypertee-contour dss hole-value ht)
+(define/own-contract (hypertee-contour dss hole-value ht)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [hole-value any/c]
+      [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
+    [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
   (w- ds (dim-successors-sys-dim-sys dss)
   #/expect
     (dim-successors-sys-dim-plus-int dss (hypertee-degree ht) 1)
@@ -1117,6 +974,7 @@
 (define-imitation-simple-struct (hypertee-coil-zero?)
   hypertee-coil-zero
   'hypertee-coil-zero (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypertee-coil-zero? (-> any/c boolean?))
 (define-imitation-simple-struct
   (hypertee-coil-hole?
     hypertee-coil-hole-overall-degree
@@ -1124,12 +982,20 @@
     hypertee-coil-hole-tails-hypertee)
   hypertee-coil-hole
   'hypertee-coil-hole (current-inspector) (auto-write) (auto-equal))
+(ascribe-own-contract hypertee-coil-hole? (-> any/c boolean?))
+(ascribe-own-contract hypertee-coil-hole-overall-degree
+  (-> hypertee-coil-hole? any/c))
+(ascribe-own-contract hypertee-coil-hole-data
+  (-> hypertee-coil-hole? any/c))
+(ascribe-own-contract hypertee-coil-hole-tails-hypertee
+  (-> hypertee-coil-hole? any/c))
 
 ; TODO PARITY: Bring this into parity with
 ; `punctaffy/hypersnippet/hypertee`, where it checks that the tails in
 ; the tails hypertee fit into the holes they're in.
 ;
-(define (hypertee-coil/c ds)
+(define/own-contract (hypertee-coil/c ds)
+  (-> dim-sys? flat-contract?)
   (rename-contract
     (or/c
       (match/c hypertee-coil-zero)
@@ -1137,7 +1003,9 @@
         (hypertee/c ds)))
     `(hypertee-coil/c ,ds)))
 
-(define (hypertee-unfurl ht)
+(define/own-contract (hypertee-unfurl ht)
+  (->i ([ht hypertee?])
+    [_ (ht) (hypertee-coil/c #/hypertee-dim-sys ht)])
   
   (struct-easy (loc-outside))
   (struct-easy (loc-dropped))
@@ -1251,13 +1119,25 @@
           (cons closing-bracket rev-result)))
     #/error "Internal error: Entered an unexpected kind of region in hypertee-unfurl")))
 
-(define (hypertee-dv-map-all-degrees ht func)
+(define/own-contract (hypertee-dv-map-all-degrees ht func)
+  (->i
+    (
+      [ht hypertee?]
+      [func (ht)
+        (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (dissect ht (hypertee ds degree closing-brackets)
   #/hypertee ds degree #/list-map closing-brackets #/fn bracket
     (expect bracket (htb-labeled d data) bracket
     #/htb-labeled d #/func d data)))
 
-(define (hypertee-v-map-one-degree degree ht func)
+(define/own-contract (hypertee-v-map-one-degree degree ht func)
+  (->i
+    (
+      [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?]
+      [func (-> any/c any/c)])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (w- ds (hypertee-dim-sys ht)
   #/hypertee-dv-map-all-degrees ht #/fn hole-degree data
     (if (dim-sys-dim=? ds degree hole-degree)
@@ -1282,10 +1162,26 @@
   
   #/hypertee-v-map-one-degree pred-degree ht func))
 
-(define (hypertee-v-map-highest-degree dss ht func)
+(define/own-contract (hypertee-v-map-highest-degree dss ht func)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)]
+      [func (-> any/c any/c)])
+    [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
   (hypertee-v-map-pred-degree dss (hypertee-degree ht) ht func))
 
-(define (hypertee-fold first-nontrivial-d ht on-zero on-hole)
+(define/own-contract
+  (hypertee-fold first-nontrivial-d ht on-zero on-hole)
+  (->i
+    (
+      [first-nontrivial-d (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?]
+      [on-zero (-> any/c)]
+      [on-hole (ht)
+        (w- ds (hypertee-dim-sys ht)
+        #/-> (dim-sys-dim/c ds) any/c (hypertee/c ds) any/c)])
+    [_ any/c])
   (w- ds (hypertee-dim-sys ht)
   #/expect (hypertee-unfurl ht)
     (hypertee-coil-hole overall-degree data tails)
@@ -1358,6 +1254,10 @@
   (current-inspector)
   (auto-write)
   (auto-equal))
+(ascribe-own-contract hypertee-join-selective-interpolation?
+  (-> any/c boolean?))
+(ascribe-own-contract hypertee-join-selective-interpolation-val
+  (-> hypertee-join-selective-interpolation? any/c))
 (define-imitation-simple-struct
   (hypertee-join-selective-non-interpolation?
     hypertee-join-selective-non-interpolation-val)
@@ -1366,6 +1266,10 @@
   (current-inspector)
   (auto-write)
   (auto-equal))
+(ascribe-own-contract hypertee-join-selective-non-interpolation?
+  (-> any/c boolean?))
+(ascribe-own-contract hypertee-join-selective-non-interpolation-val
+  (-> hypertee-join-selective-interpolation? any/c))
 
 ; This takes a hypertee of degree N where each hole value of each
 ; degree M is either a `hypertee-join-selective-interpolation`
@@ -1378,7 +1282,8 @@
 ; all the non-interpolations of the interpolations and the
 ; non-interpolations of the root.
 ;
-(define (hypertee-join-all-degrees-selective ht)
+(define/own-contract (hypertee-join-all-degrees-selective ht)
+  (-> hypertee? hypertee?)
   
   (struct-easy (state-in-root))
   (struct-easy (state-in-interpolation i))
@@ -1570,7 +1475,8 @@
       (list (state-in-interpolation root-bracket-i) histories)
       rev-result)))
 
-(define (hypertee-map-all-degrees ht func)
+(define/own-contract (hypertee-map-all-degrees ht func)
+  (-> hypertee? (-> hypertee? any/c any/c) hypertee?)
   (dissect ht (hypertee ds overall-degree closing-brackets)
   ; NOTE: This special case is necessary. Most of the code below goes
   ; smoothly for an `overall-degree` equal to `0`, but the loop ends
@@ -1652,7 +1558,13 @@
     #/htb-labeled d
       (func (hypertee ds d #/reverse rev-brackets) data))))
 
-(define (hypertee-map-one-degree degree ht func)
+(define/own-contract (hypertee-map-one-degree degree ht func)
+  (->i
+    (
+      [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?]
+      [func (ht) (-> (hypertee/c #/hypertee-dim-sys ht) any/c any/c)])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (w- ds (hypertee-dim-sys ht)
   #/hypertee-map-all-degrees ht #/fn hole data
     (if (dim-sys-dim=? ds degree #/hypertee-degree hole)
@@ -1679,10 +1591,24 @@
   
   #/hypertee-map-one-degree pred-degree ht func))
 
-(define (hypertee-map-highest-degree dss ht func)
+(define/own-contract (hypertee-map-highest-degree dss ht func)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)]
+      [func (dss)
+        (-> (hypertee/c #/dim-successors-sys-dim-sys dss) any/c
+          any/c)])
+    [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
   (hypertee-map-pred-degree dss (hypertee-degree ht) ht func))
 
-(define (hypertee-done degree data hole)
+(define/own-contract (hypertee-done degree data hole)
+  (->i
+    (
+      [degree (hole) (dim-sys-dim/c #/hypertee-dim-sys hole)]
+      [data any/c]
+      [hole hypertee?])
+    [_ (hole) (hypertee/c #/hypertee-dim-sys hole)])
   (dissect hole (hypertee ds old-degree closing-brackets)
   #/expect (dim-sys-dim<? ds old-degree degree) #t
     (raise-arguments-error 'hypertee-done
@@ -1696,7 +1622,8 @@
       (htb-unlabeled #/hypertee-bracket-degree closing-bracket)
       closing-bracket)))
 
-(define (hypertee-get-hole-zero ht)
+(define/own-contract (hypertee-get-hole-zero ht)
+  (-> hypertee? maybe?)
   (dissect ht (hypertee ds degree closing-brackets)
   #/if (dim-sys-dim=0? ds degree) (nothing)
   #/dissect (reverse closing-brackets) (cons (htb-labeled d data) _)
@@ -1710,7 +1637,8 @@
 ; which has holes for all the degree-M-or-greater holes of the
 ; interpolations of each degree M.
 ;
-(define (hypertee-join-all-degrees ht)
+(define/own-contract (hypertee-join-all-degrees ht)
+  (-> hypertee? hypertee?)
   (w- ds (hypertee-dim-sys ht)
   #/hypertee-join-all-degrees-selective
   #/hypertee-dv-map-all-degrees ht #/fn root-hole-degree data
@@ -1725,18 +1653,42 @@
         (hypertee-join-selective-non-interpolation data)
       #/hypertee-join-selective-interpolation data))))
 
-(define (hypertee-bind-all-degrees ht hole-to-ht)
+(define/own-contract (hypertee-bind-all-degrees ht hole-to-ht)
+  (->i
+    (
+      [ht hypertee?]
+      [func (ht)
+        (-> (hypertee/c #/hypertee-dim-sys ht) any/c
+          (hypertee/c #/hypertee-dim-sys ht))])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (hypertee-join-all-degrees
   #/hypertee-map-all-degrees ht hole-to-ht))
 
-(define (hypertee-bind-one-degree degree ht func)
+(define/own-contract (hypertee-bind-one-degree degree ht func)
+  (->i
+    (
+      [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?]
+      [func (ht)
+        (-> (hypertee/c #/hypertee-dim-sys ht) any/c
+          (hypertee/c #/hypertee-dim-sys ht))])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (w- ds (hypertee-dim-sys ht)
   #/hypertee-bind-all-degrees ht #/fn hole data
     (if (dim-sys-dim=? ds degree #/hypertee-degree hole)
       (func hole data)
       (hypertee-done (hypertee-degree ht) data hole))))
 
-(define (hypertee-bind-pred-degree dss degree ht func)
+(define/own-contract (hypertee-bind-pred-degree dss degree ht func)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [degree (dss) (dim-sys-dim/c #/dim-successors-sys-dim-sys dss)]
+      [ht hypertee?]
+      [func (dss)
+        (w- ds (dim-successors-sys-dim-sys dss)
+        #/-> (hypertee/c ds) any/c (hypertee/c ds))])
+    [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
   
   ; If the degree is 0 or something like a limit ordinal, we're done.
   ; No hole's degree has the given degree as its successor, so there
@@ -1758,12 +1710,25 @@
     [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
   (hypertee-bind-pred-degree dss (hypertee-degree ht) ht func))
 
-(define (hypertee-join-one-degree degree ht)
+(define/own-contract (hypertee-join-one-degree degree ht)
+  (->i
+    (
+      [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (hypertee-bind-one-degree degree ht #/fn hole data
     data))
 
-(define
+(define/own-contract
   (hypertee-set-degree-and-bind-all-degrees new-degree ht hole-to-ht)
+  (->i
+    (
+      [new-degree (ht) (dim-sys-0<dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?]
+      [hole-to-ht (ht)
+        (w- ds (hypertee-dim-sys ht)
+        #/-> (hypertee/c ds) any/c (hypertee/c ds))])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (w- ds (hypertee-dim-sys ht)
   #/w- intermediate-degree
     (dim-sys-dim-max ds new-degree (hypertee-degree ht))
@@ -1784,7 +1749,13 @@
         "hole-to-ht-result" result)
     #/hypertee-increase-degree-to intermediate-degree result)))
 
-(define (hypertee-append-zero ds degree hts)
+(define/own-contract (hypertee-append-zero ds degree hts)
+  (->i
+    (
+      [ds dim-sys?]
+      [degree (ds) (dim-sys-0<dim/c ds)]
+      [hts (ds) (listof #/hypertee/c ds)])
+    [_ (ds) (hypertee/c ds)])
   (begin
     ; TODO DOCS: See if we can verify these things in the contract.
     (list-each hts #/fn ht
@@ -1810,7 +1781,13 @@
       (dissect data (trivial)
         tail))))
 
-(define (hypertee-dv-any-all-degrees ht func)
+(define/own-contract (hypertee-dv-any-all-degrees ht func)
+  (->i
+    (
+      [ht hypertee?]
+      [func (ht)
+        (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
+    [_ any/c])
   (dissect ht (hypertee ds degree closing-brackets)
   #/list-any closing-brackets #/fn bracket
     (expect bracket (htb-labeled d data) #f
@@ -1838,7 +1815,13 @@
     (dissect hole-and-data (list hole data)
     #/func hole data)))
 
-(define (hypertee-dv-all-all-degrees ht func)
+(define/own-contract (hypertee-dv-all-all-degrees ht func)
+  (->i
+    (
+      [ht hypertee?]
+      [func (ht)
+        (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
+    [_ any/c])
   (dissect ht (hypertee ds degree closing-brackets)
   #/list-all closing-brackets #/fn bracket
     (expect bracket (htb-labeled d data) #t
@@ -1853,25 +1836,40 @@
     (dissect hole-and-data (list hole data)
     #/func hole data)))
 
-(define (hypertee-dv-each-all-degrees ht body)
+(define/own-contract (hypertee-dv-each-all-degrees ht body)
+  (->i
+    (
+      [ht hypertee?]
+      [func (ht)
+        (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any)])
+    [_ void?])
   (hypertee-dv-any-all-degrees ht #/fn d data #/begin
     (body d data)
     #f)
   (void))
 
-(define (hypertee-v-each-one-degree degree ht body)
+(define/own-contract (hypertee-v-each-one-degree degree ht body)
+  (->i
+    (
+      [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?]
+      [body (ht) (-> any/c any)])
+    [_ void?])
   (w- ds (hypertee-dim-sys ht)
   #/hypertee-dv-each-all-degrees ht #/fn d data
     (when (dim-sys-dim=? ds degree d)
       (body data))))
 
-(define (hypertee-each-all-degrees ht body)
+(define/own-contract (hypertee-each-all-degrees ht body)
+  (-> hypertee? (-> hypertee? any/c any) void?)
   (hypertee-any-all-degrees ht #/fn hole data #/begin
     (body hole data)
     #f)
   (void))
 
-(define (hypertee-furl ds coil)
+(define/own-contract (hypertee-furl ds coil)
+  (->i ([ds dim-sys?] [coil (ds) (hypertee-coil/c ds)])
+    [_ (ds) (hypertee/c ds)])
   (expect coil (hypertee-coil-hole degree data tails)
     (hypertee ds (dim-sys-dim-zero ds) #/list)
   #/expect (dim-sys-dim<? ds (hypertee-degree tails) degree) #t
@@ -1914,7 +1912,15 @@
     #/hypertee-dv-all-all-degrees tails #/fn d tail
       (next (fn d2 #/dim-sys-dim=? ds d d2) tail))))
 
-(define (hypertee-uncontour dss ht)
+(define/own-contract (hypertee-uncontour dss ht)
+  (->i
+    (
+      [dss dim-successors-sys?]
+      [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])
+    [_ (dss)
+      (maybe/c #/list/c
+        any/c
+        (hypertee/c #/dim-successors-sys-dim-sys dss))])
   (expect (hypertee-contour? dss ht) #t (nothing)
   #/dissect (hypertee-unfurl ht)
     (hypertee-coil-hole overall-degree data tails)
@@ -1946,7 +1952,8 @@
 
 ; This takes a hypertee and removes all holes which don't satisfy the
 ; given predicate.
-(define (hypertee-filter ht should-keep?)
+(define/own-contract (hypertee-filter ht should-keep?)
+  (-> hypertee? (-> hypertee? any/c boolean?) hypertee?)
   (dissect ht (hypertee ds d closing-brackets)
   #/hypertee-bind-all-degrees ht #/fn hole data
     (if (should-keep? hole data)
@@ -1959,7 +1966,12 @@
 ; greater than a given degree, and demotes the hypertee to that
 ; degree. The given degree must not be greater than the hypertee's
 ; existing degree.
-(define (hypertee-filter-degree-to new-degree ht)
+(define/own-contract (hypertee-filter-degree-to new-degree ht)
+  (->i
+    (
+      [new-degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
+      [ht hypertee?])
+    [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])
   (dissect ht (hypertee ds d closing-brackets)
   #/expect (dim-sys-dim<=? ds new-degree d) #t
     (error "Expected ht to be a hypertee of degree no less than new-degree")
@@ -2028,7 +2040,17 @@
     #/expect maybe-elem (just elem) (list state #/nothing)
     #/next state lst (cons elem rev-result))))
 
-(define (hypertee-dv-fold-map-any-all-degrees state ht on-hole)
+(define/own-contract
+  (hypertee-dv-fold-map-any-all-degrees state ht on-hole)
+  (->i
+    (
+      [state any/c]
+      [ht hypertee?]
+      [on-hole (ht)
+        (-> any/c (dim-sys-dim/c #/hypertee-dim-sys ht) any/c
+          (list/c any/c #/maybe/c any/c))])
+    [_ (ht)
+      (list/c any/c #/maybe/c #/hypertee/c #/hypertee-dim-sys ht)])
   (dissect ht (hypertee ds d closing-brackets)
   #/dissect
     (list-fold-map-any state closing-brackets #/fn state bracket
@@ -2045,8 +2067,18 @@
 ; if the hypertees have the same shape when certain holes of the
 ; higher-degree hypertee are removed -- namely, the holes of degree N
 ; or greater and the holes that don't match the given predicate.
-(define
+(define/own-contract
   (hypertee-selective-holes-zip-map smaller bigger should-zip? func)
+  (->i
+    (
+      [smaller (bigger) (hypertee/c #/hypertee-dim-sys bigger)]
+      [bigger hypertee?]
+      [should-zip? (bigger)
+        (-> (hypertee/c #/hypertee-dim-sys bigger) any/c boolean?)]
+      [func (bigger)
+        (-> (hypertee/c #/hypertee-dim-sys bigger) any/c any/c
+          any/c)])
+    [_ (bigger) (maybe/c #/hypertee/c #/hypertee-dim-sys bigger)])
   (dissect smaller (hypertee _ d-smaller closing-brackets-smaller)
   #/dissect bigger (hypertee ds d-bigger closing-brackets-bigger)
   #/expect (dim-sys-dim<=? ds d-smaller d-bigger) #t
@@ -2088,6 +2120,9 @@
 
 ; This zips a degree-N hypertee with a same-degree-or-higher hypertee
 ; if the hypertees have the same shape when truncated to degree N.
-(define (hypertee-low-degree-holes-zip-map smaller bigger func)
+(define/own-contract
+  (hypertee-low-degree-holes-zip-map smaller bigger func)
+  (-> hypertee? hypertee? (-> hypertee? any/c any/c any/c)
+    (maybe/c hypertee?))
   (hypertee-selective-holes-zip-map
     smaller bigger (fn hole data #t) func))

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -6,7 +6,7 @@
 ; that occurs in higher quasiquotation (represented in a
 ; sequence-of-brackets style).
 
-;   Copyright 2017-2019 The Lathe Authors
+;   Copyright 2017-2020, 2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@
 
 
 (require #/only-in racket/contract/base
-  -> ->i and/c any any/c contract? contract-name contract-out list/c
-  listof not/c or/c rename-contract)
+  -> ->i and/c any any/c contract? contract-name contract-out
+  flat-contract? list/c listof not/c or/c rename-contract)
 (require #/only-in racket/contract/combinator
   coerce-contract contract-first-order-passes?)
 (require #/only-in racket/math natural?)
@@ -130,7 +130,7 @@
   [hypertee-get-brackets
     (->i ([ht hypertee?])
       [_ (ht)
-        (w- ds (hypertee-get-dim-sys ht)
+        (w- ds (hypertee-dim-sys ht)
         #/listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])]
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
@@ -304,11 +304,13 @@
           (-> (hypertee/c #/dim-successors-sys-dim-sys dss) any/c
             any/c)])
       [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])]
-  ; TODO PARITY: Continue looking for things to bring into parity from
-  ; here. Once we're done looking for them here, continue looking in
-  ; `punctaffy/private/hypernest-as-ast`, and look for things exported
-  ; by `punctaffy/hypersnippet/hypertee` and
-  ; `punctaffy/hypersnippet/hypernest` that these don't export.
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypertee-snippet-sys` and
+  ; `snippet-sys-snippet-done`. If it did exist, it would pass the
+  ; hole shape argument before the data argument, and it would use a
+  ; more specific contract that asserted the result was of the
+  ; requested degree.
   [hypertee-done
     (->i
       (
@@ -316,6 +318,11 @@
         [data any/c]
         [hole hypertee?])
       [_ (hole) (hypertee/c #/hypertee-dim-sys hole)])]
+  ; TODO PARITY: Continue looking for things to bring into parity from
+  ; here. Once we're done looking for them here, continue looking in
+  ; `punctaffy/private/hypernest-as-ast`, and look for things exported
+  ; by `punctaffy/hypersnippet/hypertee` and
+  ; `punctaffy/hypersnippet/hypernest` that these don't export.
   [hypertee-get-hole-zero (-> hypertee? maybe?)]
   [hypertee-furl
     (->i

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -75,15 +75,20 @@
 (provide #/contract-out
   [hypertee-bracket? (-> any/c boolean?)]
   [hypertee-bracket/c (-> contract? contract?)]
-  [hypertee-bracket-degree (-> (hypertee-bracket/c any/c) any/c)]
+  [hypertee-bracket-degree (-> hypertee-bracket? any/c)]
   [hypertee? (-> any/c boolean?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it's called
+  ; `hypertee-get-dim-sys`.
   [hypertee-dim-sys (-> hypertee? dim-sys?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it isn't exported.
   [hypertee-degree
     (->i ([ht hypertee?])
       [_ (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)])]
   ; TODO DOCS: Consider more expressive hypertee contract combinators
   ; than `hypertee/c`, and come up with a new name for it.
-  [hypertee/c (-> dim-sys? contract?)])
+  [hypertee/c (-> dim-sys? flat-contract?)])
 (module+ unsafe #/provide #/contract-out
   [unsafe-hypertee-from-brackets (-> dim-sys? any/c any/c any)])
 (provide #/contract-out
@@ -104,6 +109,8 @@
           (hypertee-bracket/c dim/c)
           (and/c (not/c hypertee-bracket?) dim/c))]
       [_ (ds) (hypertee/c ds)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
   [ht-bracs-dss
     (->i
       (
@@ -123,26 +130,40 @@
   [hypertee-get-brackets
     (->i ([ht hypertee?])
       [_ (ht)
-        (listof
-        #/hypertee-bracket/c #/dim-sys-dim/c #/hypertee-dim-sys ht)])]
+        (w- ds (hypertee-get-dim-sys ht)
+        #/listof #/hypertee-bracket/c #/dim-sys-dim/c ds)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
+  ; did exist, it would use a more specific contract that asserted the
+  ; result was of the requested degree.
   [hypertee-increase-degree-to
     (->i
       (
         [new-degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
         [ht hypertee?])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
+  ; did exist, it would use a more specific contract that asserted the
+  ; result was of the requested degree.
   [hypertee-set-degree-maybe
     (->i
       (
         [new-degree (ht) (dim-sys-0<dim/c #/hypertee-dim-sys ht)]
         [ht hypertee?])
       [_ (ht) (maybe/c #/hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
+  ; did exist, it would use a more specific contract that asserted the
+  ; result was of the requested degree.
   [hypertee-set-degree-force
     (->i
       (
         [new-degree (ht) (dim-sys-0<dim/c #/hypertee-dim-sys ht)]
         [ht hypertee?])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
   [hypertee-contour
     (->i
       (
@@ -157,17 +178,31 @@
 (provide
   hypertee-coil-hole)
 (provide #/contract-out
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where there's an extra
+  ; `hypertee-coil-hole-hole` field and
+  ; `hypertee-coil-hole-tails-hypertee` is called
+  ; `hypertee-coil-hole-tails`.
   [hypertee-coil-hole? (-> any/c boolean?)]
   [hypertee-coil-hole-overall-degree (-> hypertee-coil-hole? any/c)]
   [hypertee-coil-hole-data (-> hypertee-coil-hole? any/c)]
   [hypertee-coil-hole-tails-hypertee
     (-> hypertee-coil-hole? any/c)])
 (provide #/contract-out
-  [hypertee-coil/c (-> dim-sys? contract?)])
+  [hypertee-coil/c (-> dim-sys? flat-contract?)])
 (provide #/contract-out
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it's called
+  ; `hypertee-get-coil`.
   [hypertee-unfurl
     (->i ([ht hypertee?])
       [_ (ht) (hypertee-coil/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
+  ; did exist, it would be called `hypertee-map`, it would pass its
+  ; callback a hole shape rather than merely a degree, and it would
+  ; use a more specific contract that asserted the result was of the
+  ; same degree as the original.
   [hypertee-dv-map-all-degrees
     (->i
       (
@@ -175,6 +210,15 @@
         [func (ht)
           (-> (dim-sys-dim/c #/hypertee-dim-sys ht) any/c any/c)])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys`, `snippet-sys-snippet-select-if-degree`,
+  ; and `snippet-sys-snippet-map-selective`. If it did exist, it would
+  ; be called `hypertee-map-if-degree=`, it would pass its callback a
+  ; hole shape in addition to the value, and it would use a more
+  ; specific contract that asserted the result was of the same degree
+  ; as the original.
   [hypertee-v-map-one-degree
     (->i
       (
@@ -182,6 +226,8 @@
         [ht hypertee?]
         [func (-> any/c any/c)])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
   [hypertee-v-map-highest-degree
     (->i
       (
@@ -189,6 +235,8 @@
         [ht (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)]
         [func (-> any/c any/c)])
       [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
   [hypertee-fold
     (->i
       (
@@ -201,21 +249,43 @@
           #/-> (dim-sys-dim/c ds) any/c (hypertee/c ds) any/c)])
       [_ any/c])])
 (provide
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it's called `selected`.
   hypertee-join-selective-interpolation)
 (provide #/contract-out
   [hypertee-join-selective-interpolation? (-> any/c boolean?)]
   [hypertee-join-selective-interpolation-val
     (-> hypertee-join-selective-interpolation? any/c)])
 (provide
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it's called `unselected`.
   hypertee-join-selective-non-interpolation)
 (provide #/contract-out
   [hypertee-join-selective-non-interpolation? (-> any/c boolean?)]
   [hypertee-join-selective-non-interpolation-val
     (-> hypertee-join-selective-interpolation? any/c)])
 (provide #/contract-out
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys` and `snippet-sys-snippet-join-selective`.
+  ; If it did exist, it would be called `hypertee-join-selective`, and
+  ; it would use a much more specific contract.
   [hypertee-join-all-degrees-selective (-> hypertee? hypertee?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
+  ; did exist, it would be called `hypertee-map`, and it would use a
+  ; much more specific contract.
   [hypertee-map-all-degrees
     (-> hypertee? (-> hypertee? any/c any/c) hypertee?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would probably be accommodated through a mix of
+  ; `hypertee-snippet-sys`, `snippet-sys-snippet-select-if-degree`,
+  ; and `snippet-sys-snippet-map-selective`. If it did exist, it would
+  ; be called `hypertee-map-if-degree=`, and it would use a more
+  ; specific contract that asserted the result was of the same degree
+  ; as the original.
   [hypertee-map-one-degree
     (->i
       (
@@ -223,6 +293,8 @@
         [ht hypertee?]
         [func (ht) (-> (hypertee/c #/hypertee-dim-sys ht) any/c any/c)])
       [_ (ht) (hypertee/c #/hypertee-dim-sys ht)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist.
   [hypertee-map-highest-degree
     (->i
       (
@@ -232,6 +304,11 @@
           (-> (hypertee/c #/dim-successors-sys-dim-sys dss) any/c
             any/c)])
       [_ (dss) (hypertee/c #/dim-successors-sys-dim-sys dss)])]
+  ; TODO PARITY: Continue looking for things to bring into parity from
+  ; here. Once we're done looking for them here, continue looking in
+  ; `punctaffy/private/hypernest-as-ast`, and look for things exported
+  ; by `punctaffy/hypersnippet/hypertee` and
+  ; `punctaffy/hypersnippet/hypernest` that these don't export.
   [hypertee-done
     (->i
       (
@@ -912,6 +989,10 @@
   hypertee-coil-hole
   'hypertee-coil-hole (current-inspector) (auto-write) (auto-equal))
 
+; TODO PARITY: Bring this into parity with
+; `punctaffy/hypersnippet/hypertee`, where it checks that the tails in
+; the tails hypertee fit into the holes they're in.
+;
 (define (hypertee-coil/c ds)
   (rename-contract
     (or/c

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -26,7 +26,6 @@
   listof not/c or/c rename-contract)
 (require #/only-in racket/contract/combinator
   coerce-contract contract-first-order-passes?)
-(require #/only-in racket/contract/region define/contract)
 (require #/only-in racket/math natural?)
 (require #/only-in racket/struct make-constructor-style-printer)
 
@@ -46,6 +45,9 @@
 (require #/only-in lathe-comforts/trivial trivial)
 (require #/only-in lathe-morphisms/in-fp/mediary/set ok/c)
 
+(require punctaffy/private/shim)
+(init-shim)
+
 (require #/only-in punctaffy/hypersnippet/dim
   dim-successors-sys? dim-successors-sys-dim-from-int
   dim-successors-sys-dim-plus-int dim-successors-sys-dim=plus-int?
@@ -57,6 +59,7 @@
   hyperstack-push make-hyperstack-trivial make-hyperstack)
 (require #/only-in punctaffy/private/suppress-internal-errors
   punctaffy-suppress-internal-errors)
+
 
 (provide
   htb-labeled)
@@ -1044,7 +1047,7 @@
       (func data)
       data)))
 
-(define/contract (hypertee-v-map-pred-degree dss degree ht func)
+(define/own-contract (hypertee-v-map-pred-degree dss degree ht func)
   (->i
     (
       [dss dim-successors-sys?]
@@ -1439,7 +1442,7 @@
       (func hole data)
       data)))
 
-(define/contract (hypertee-map-pred-degree dss degree ht func)
+(define/own-contract (hypertee-map-pred-degree dss degree ht func)
   (->i
     (
       [dss dim-successors-sys?]
@@ -1527,7 +1530,7 @@
   
   #/hypertee-bind-one-degree pred-degree ht func))
 
-(define/contract (hypertee-bind-highest-degree dss ht func)
+(define/own-contract (hypertee-bind-highest-degree dss ht func)
   (->i
     (
       [dss dim-successors-sys?]
@@ -1597,7 +1600,7 @@
     #/func d data)))
 
 ; TODO: See if we'll use this.
-(define/contract (hypertee-v-any-one-degree degree ht func)
+(define/own-contract (hypertee-v-any-one-degree degree ht func)
   (->i
     (
       [degree (ht) (dim-sys-dim/c #/hypertee-dim-sys ht)]
@@ -1609,7 +1612,7 @@
     (and (dim-sys-dim=? ds degree d)
     #/func data)))
 
-(define/contract (hypertee-any-all-degrees ht func)
+(define/own-contract (hypertee-any-all-degrees ht func)
   (-> hypertee? (-> hypertee? any/c any/c) any/c)
   (hypertee-dv-any-all-degrees
     (hypertee-map-all-degrees ht #/fn hole data
@@ -1624,7 +1627,7 @@
     (expect bracket (htb-labeled d data) #t
     #/func d data)))
 
-(define/contract (hypertee-all-all-degrees ht func)
+(define/own-contract (hypertee-all-all-degrees ht func)
   (-> hypertee? (-> hypertee? any/c any/c) any/c)
   (hypertee-dv-all-all-degrees
     (hypertee-map-all-degrees ht #/fn hole data
@@ -1675,7 +1678,7 @@
       (trivial))
     tails))
 
-(define/contract (hypertee-contour? dss ht)
+(define/own-contract (hypertee-contour? dss ht)
   (->i
     (
       [dss dim-successors-sys?]
@@ -1753,7 +1756,7 @@
     (hypertee ds d closing-brackets)
   #/hypertee ds new-degree closing-brackets))
 
-(define/contract (hypertee-zip-map a b func)
+(define/own-contract (hypertee-zip-map a b func)
   (->i
     (
       [a (b) (hypertee/c #/hypertee-dim-sys b)]
@@ -1798,7 +1801,7 @@
     #/func hole a b)))
 
 ; TODO: See if we should add this to Lathe Comforts.
-(define/contract (list-fold-map-any state lst on-elem)
+(define/own-contract (list-fold-map-any state lst on-elem)
   (-> any/c list? (-> any/c any/c #/list/c any/c #/maybe/c any/c)
     (list/c any/c #/maybe/c list?))
   (w-loop next state state lst lst rev-result (list)

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -282,9 +282,10 @@
   ; specific contract.
   [hypertee-join-all-degrees-selective (-> hypertee? hypertee?)]
   ; TODO PARITY: Bring this into parity with
-  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. If it
-  ; did exist, it would be called `hypertee-map`, and it would use a
-  ; much more specific contract.
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypertee-snippet-sys` and
+  ; `snippet-sys-snippet-map`. If it did exist, it would be called
+  ; `hypertee-map`, and it would use a much more specific contract.
   [hypertee-map-all-degrees
     (-> hypertee? (-> hypertee? any/c any/c) hypertee?)]
   ; TODO PARITY: Bring this into parity with
@@ -331,11 +332,11 @@
   ; `punctaffy/hypersnippet/hypertee`, where it's called
   ; `hypertee-get-hole-zero-maybe` and has a more specific contract.
   [hypertee-get-hole-zero (-> hypertee? maybe?)]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't have as strict
+  ; a result contract and it has a match expander.
   [hypertee-furl
-    (->i
-      (
-        [ds dim-sys?]
-        [coil (ds) (hypertee-coil/c ds)])
+    (->i ([ds dim-sys?] [coil (ds) (hypertee-coil/c ds)])
       [_ (ds) (hypertee/c ds)])]
   ; TODO PARITY: Bring this into parity with
   ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It

--- a/punctaffy-lib/private/hypertee-as-brackets.rkt
+++ b/punctaffy-lib/private/hypertee-as-brackets.rkt
@@ -318,11 +318,9 @@
         [data any/c]
         [hole hypertee?])
       [_ (hole) (hypertee/c #/hypertee-dim-sys hole)])]
-  ; TODO PARITY: Continue looking for things to bring into parity from
-  ; here. Once we're done looking for them here, continue looking in
-  ; `punctaffy/private/hypernest-as-ast`, and look for things exported
-  ; by `punctaffy/hypersnippet/hypertee` and
-  ; `punctaffy/hypersnippet/hypernest` that these don't export.
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it's called
+  ; `hypertee-get-hole-zero-maybe` and has a more specific contract.
   [hypertee-get-hole-zero (-> hypertee? maybe?)]
   [hypertee-furl
     (->i
@@ -330,7 +328,17 @@
         [ds dim-sys?]
         [coil (ds) (hypertee-coil/c ds)])
       [_ (ds) (hypertee/c ds)])]
+  ; TODO PARITY: Bring this into parity with
+  ; `punctaffy/hypersnippet/hypertee`, where it doesn't exist. It
+  ; would be accommodated through a mix of `hypertee-snippet-sys` and
+  ; `snippet-sys-snippet-join`. If it did exist, it would be called
+  ; `hypertee-join`, and it would use a much more specific contract.
   [hypertee-join-all-degrees (-> hypertee? hypertee?)]
+  ; TODO PARITY: Continue looking for things to bring into parity from
+  ; here. Once we're done looking for them here, continue looking in
+  ; `punctaffy/private/hypernest-as-ast`, and look for things exported
+  ; by `punctaffy/hypersnippet/hypertee` and
+  ; `punctaffy/hypersnippet/hypernest` that these don't export.
   [hypertee-bind-all-degrees
     (->i
       (

--- a/punctaffy-lib/private/shim.rkt
+++ b/punctaffy-lib/private/shim.rkt
@@ -20,7 +20,16 @@
 ;   language governing permissions and limitations under the License.
 
 
-(require /for-syntax /only-in racket/syntax format-id)
+(require /only-in reprovide/require-transformer/combine-in-fallback
+  combine-in/fallback)
+
+(require /for-syntax /combine-in/fallback
+  (combine-in
+    (only-in racket/syntax format-id)
+    (only-in syntax/parse ~optional ~seq this-syntax))
+  racket/base)
+
+(require /only-in syntax/parse/define define-syntax-parse-rule)
 
 (require /only-in reprovide/reprovide reprovide)
 

--- a/punctaffy-lib/private/shim.rkt
+++ b/punctaffy-lib/private/shim.rkt
@@ -1,11 +1,11 @@
-#lang parendown racket/base
+#lang parendown/slash racket/base
 
 ; shim.rkt
 ;
 ; Import lists, debugging constants, and other utilities that are
 ; useful primarily for this codebase.
 
-;   Copyright 2021 The Lathe Authors
+;   Copyright 2022 The Lathe Authors
 ;
 ;   Licensed under the Apache License, Version 2.0 (the "License");
 ;   you may not use this file except in compliance with the License.
@@ -20,48 +20,47 @@
 ;   language governing permissions and limitations under the License.
 
 
-(require #/for-syntax racket/base)
+(require /for-syntax /only-in racket/syntax format-id)
 
-(require #/for-syntax #/only-in racket/syntax syntax-local-eval)
-(require #/for-syntax #/only-in syntax/parse expr id syntax-parse)
+(require /only-in reprovide/reprovide reprovide)
 
+(require /only-in lathe-comforts/own-contract
+  define-own-contract-policies)
+
+(reprovide punctaffy/private/codebasewide-requires)
 
 (provide
-  shim-contract-out
-  shim-recontract-out)
+  (for-syntax
+    suppressing-external-contracts?
+    activating-internal-contracts?)
+  init-shim)
 
 
-; NOTE DEBUGGABILITY: These are here for debugging.
-(define-for-syntax debugging-with-contracts-suppressed #f)
+; Should be `#f` unless we're debugging to determine if contracts are
+; a performance bottleneck.
+;
+(define-for-syntax suppressing-external-contracts? #f)
 
-(define-syntax (ifc stx)
-  (syntax-protect
-  #/syntax-parse stx #/ (_ condition:expr then:expr else:expr)
-  #/if (syntax-local-eval #'condition)
-    #'then
-    #'else))
+; Should be `#f` unless we're debugging this library's internal call
+; graph.
+;
+(define-for-syntax activating-internal-contracts? #f)
 
-; TODO: Figure out what to do with this section. Should we provide
-; `.../with-contracts-suppressed/...` modules? For now, we have this
-; here for testing.
-
-(ifc debugging-with-contracts-suppressed
-  (begin
-    (require #/for-syntax #/only-in racket/provide-transform
-      expand-export make-provide-transformer)
-    
-    (require #/for-syntax #/only-in lathe-comforts fn)
-    
-    (define-syntax shim-contract-out
-      (make-provide-transformer #/fn stx modes
-        (syntax-parse stx #/ (_ [var:id contract:expr] ...)
-        #/expand-export #'(combine-out var ...) modes)))
-    
-    (define-syntax shim-recontract-out
-      (make-provide-transformer #/fn stx modes
-        (syntax-parse stx #/ (_ var:id ...)
-        #/expand-export #'(combine-out var ...) modes))))
-  (begin
-    (require #/only-in racket/contract/base
-      [contract-out shim-contract-out]
-      [recontract-out shim-recontract-out])))
+(define-syntax-parse-rule
+  (init-shim
+    {~optional {~seq #:antecedent-land antecedent-land}
+      #:defaults ([antecedent-land (datum->syntax this-syntax '())])})
+  
+  #:with result
+  #`(define-own-contract-policies #:antecedent-land antecedent-land
+      
+      #:make-signature-contract-id
+      (lambda (orig) /format-id orig "~a/sig-c" orig #:subs? #t)
+      
+      #:suppressing-external-contracts?
+      #,(datum->syntax #'() suppressing-external-contracts?)
+      
+      #:activating-internal-contracts?
+      #,(datum->syntax #'() activating-internal-contracts?))
+  
+  result)


### PR DESCRIPTION
Using the `lathe-comforts/own-contract` DSL should allow somewhat easier maintenance of our contracts. One of the biggest benefits will be the ability to migrate a lot of code that's still using `define/contract` so that those contracts can be disabled for internal calls within the same module.

This won't be ready to merge for a while. It will likely take several commits to complete.